### PR TITLE
Send functionality

### DIFF
--- a/src/manager/outgoing.rs
+++ b/src/manager/outgoing.rs
@@ -67,10 +67,35 @@ struct DataMessageProto {
     timestamp: Option<u64>,
 }
 
+// SyncMessage.Sent (signalservice.proto). Field tags per canonical proto:
+//   destinationE164      = 1   (omitted; we use destinationServiceId)
+//   timestamp            = 2
+//   message              = 3   (DataMessage)
+//   destinationServiceId = 7
+#[derive(prost::Message)]
+struct SentMessageProto {
+    #[prost(uint64, optional, tag = "2")]
+    timestamp: Option<u64>,
+    #[prost(message, optional, tag = "3")]
+    message: Option<DataMessageProto>,
+    #[prost(string, optional, tag = "7")]
+    destination_service_id: Option<String>,
+}
+
+// SyncMessage container. SyncMessage.sent = 1.
+#[derive(prost::Message)]
+struct SyncMessageProto {
+    #[prost(message, optional, tag = "1")]
+    sent: Option<SentMessageProto>,
+}
+
+// Content (signalservice.proto). Content.dataMessage = 1, Content.syncMessage = 2.
 #[derive(prost::Message)]
 struct ContentProto {
     #[prost(message, optional, tag = "1")]
     data_message: Option<DataMessageProto>,
+    #[prost(message, optional, tag = "2")]
+    sync_message: Option<SyncMessageProto>,
 }
 
 // ---- Public types -----------------------------------------------------------
@@ -140,10 +165,88 @@ pub(crate) fn signal_pad(content: &mut Vec<u8>) {
     }
 }
 
-// ---- Generic encrypt over abstract stores (testable without pddb) ----------
+// ---- Content builders ------------------------------------------------------
 
-pub(crate) fn build_encrypted_message_with_stores<S, I>(
+/// Build the padded `Content { dataMessage }` for an outbound text message.
+/// Caller passes the result to `encrypt_padded_for_recipient`.
+pub(crate) fn build_padded_data_message_content(
     plaintext_body: &str,
+    timestamp_ms: u64,
+) -> Vec<u8> {
+    let dm = DataMessageProto {
+        body: Some(plaintext_body.to_string()),
+        timestamp: Some(timestamp_ms),
+    };
+    let content = ContentProto {
+        data_message: Some(dm),
+        sync_message: None,
+    };
+    let mut bytes = content.encode_to_vec();
+    if std::env::var("XSCDEBUG_DUMP").is_ok() {
+        let _ = dump_hex(
+            "Content protobuf (DataMessage, pre-encrypt, pre-pad)",
+            timestamp_ms,
+            &bytes,
+        );
+    }
+    signal_pad(&mut bytes);
+    if std::env::var("XSCDEBUG_DUMP").is_ok() {
+        let _ = dump_hex(
+            "Padded plaintext (DataMessage, post-pad, pre-encrypt)",
+            timestamp_ms,
+            &bytes,
+        );
+    }
+    bytes
+}
+
+/// Build the padded `Content { syncMessage { sent } }` for the sync transcript
+/// that the sender's own account's other devices receive after an outbound
+/// send. Wraps a copy of the original DataMessage; recipient-side service ID
+/// and timestamp echo through.
+pub(crate) fn build_padded_sync_transcript_content(
+    recipient_uuid: &str,
+    plaintext_body: &str,
+    timestamp_ms: u64,
+) -> Vec<u8> {
+    let inner_dm = DataMessageProto {
+        body: Some(plaintext_body.to_string()),
+        timestamp: Some(timestamp_ms),
+    };
+    let sent = SentMessageProto {
+        timestamp: Some(timestamp_ms),
+        message: Some(inner_dm),
+        destination_service_id: Some(recipient_uuid.to_string()),
+    };
+    let sync = SyncMessageProto { sent: Some(sent) };
+    let content = ContentProto {
+        data_message: None,
+        sync_message: Some(sync),
+    };
+    let mut bytes = content.encode_to_vec();
+    if std::env::var("XSCDEBUG_DUMP").is_ok() {
+        let _ = dump_hex(
+            "Content protobuf (SyncMessage::Sent, pre-encrypt, pre-pad)",
+            timestamp_ms,
+            &bytes,
+        );
+    }
+    signal_pad(&mut bytes);
+    if std::env::var("XSCDEBUG_DUMP").is_ok() {
+        let _ = dump_hex(
+            "Padded plaintext (SyncMessage::Sent, post-pad, pre-encrypt)",
+            timestamp_ms,
+            &bytes,
+        );
+    }
+    bytes
+}
+
+/// Encrypt pre-padded Content bytes for a single recipient device. Used for
+/// both the main DataMessage send path and the sync transcript path; the
+/// content variant is encoded in the plaintext bytes themselves.
+pub(crate) fn encrypt_padded_for_recipient<S, I>(
+    padded_content: &[u8],
     timestamp_ms: u64,
     recipient_addr: &ProtocolAddress,
     local_addr: &ProtocolAddress,
@@ -154,35 +257,6 @@ where
     S: SessionStore,
     I: IdentityKeyStore,
 {
-    // (1) Build Content { DataMessage }
-    let dm = DataMessageProto {
-        body: Some(plaintext_body.to_string()),
-        timestamp: Some(timestamp_ms),
-    };
-    let content = ContentProto { data_message: Some(dm) };
-    let mut content_bytes = content.encode_to_vec();
-
-    // [Phase A v5 audit] uncommitted diagnostic — dump pre-pad bytes.
-    if std::env::var("XSCDEBUG_DUMP").is_ok() {
-        let _ = dump_hex(
-            "Content protobuf (pre-encrypt, pre-pad)",
-            timestamp_ms,
-            &content_bytes,
-        );
-    }
-
-    // (2) Pad
-    signal_pad(&mut content_bytes);
-
-    if std::env::var("XSCDEBUG_DUMP").is_ok() {
-        let _ = dump_hex(
-            "Padded plaintext (post-pad, pre-encrypt)",
-            timestamp_ms,
-            &content_bytes,
-        );
-    }
-
-    // (3) Look up dest_registration_id from the session record.
     let session_record = block_on(session_store.load_session(recipient_addr))
         .map_err(|e| OutgoingError::SessionLoad(format!("{e:?}")))?
         .ok_or(OutgoingError::NoSession)?;
@@ -190,10 +264,9 @@ where
         .remote_registration_id()
         .map_err(|e| OutgoingError::RegistrationId(format!("{e:?}")))?;
 
-    // (4) Encrypt.
     let mut rng = rand::rngs::OsRng.unwrap_err();
     let ciphertext_message = block_on(message_encrypt(
-        &content_bytes,
+        padded_content,
         recipient_addr,
         local_addr,
         session_store,
@@ -203,7 +276,6 @@ where
     ))
     .map_err(|e| OutgoingError::Encrypt(format!("{e:?}")))?;
 
-    // (5) Map variant → envelope type code.
     let (ciphertext_bytes, ciphertext_type) = match ciphertext_message {
         CiphertextMessage::SignalMessage(msg) => {
             (msg.serialized().to_vec(), ENVELOPE_CIPHERTEXT)
@@ -238,6 +310,31 @@ where
         destination_registration_id: dest_reg_id,
         timestamp_ms,
     })
+}
+
+// ---- Generic encrypt over abstract stores (testable without pddb) ----------
+
+pub(crate) fn build_encrypted_message_with_stores<S, I>(
+    plaintext_body: &str,
+    timestamp_ms: u64,
+    recipient_addr: &ProtocolAddress,
+    local_addr: &ProtocolAddress,
+    session_store: &mut S,
+    identity_store: &mut I,
+) -> Result<EncryptedMessage, OutgoingError>
+where
+    S: SessionStore,
+    I: IdentityKeyStore,
+{
+    let padded = build_padded_data_message_content(plaintext_body, timestamp_ms);
+    encrypt_padded_for_recipient(
+        &padded,
+        timestamp_ms,
+        recipient_addr,
+        local_addr,
+        session_store,
+        identity_store,
+    )
 }
 
 // ---- Production wrapper: opens pddb stores, reads local account ------------

--- a/src/manager/send.rs
+++ b/src/manager/send.rs
@@ -81,6 +81,8 @@ use url::Url;
 
 use crate::manager::outgoing::{
     EncryptedMessage, OutgoingError, build_encrypted_message_with_stores,
+    build_padded_data_message_content, build_padded_sync_transcript_content,
+    encrypt_padded_for_recipient,
 };
 use crate::manager::stores::{PddbIdentityStore, PddbSessionStore};
 
@@ -508,23 +510,26 @@ impl DeviceSessionEnum for PddbSessionStore {
     }
 }
 
-/// Generic core of the retry loop. Driven by the production wrapper with
-/// pddb-backed stores; driven by tests with `InMemSignalProtocolStore`'s
-/// pieces.
+/// Generic core of the retry loop, parameterized on pre-built padded Content
+/// bytes. Both the recipient send path (DataMessage Content) and the sync
+/// transcript path (SyncMessage Content) drive this same loop with different
+/// `padded_content`.
 ///
-/// On each attempt we enumerate every device for which we have a session
-/// (via `session_store.device_ids_for(uuid)`), encrypt the plaintext for
-/// each, and submit them all in one PUT. On 409/410 we update the local
-/// session set; the next iteration's enumeration picks up the changes
-/// naturally.
+/// On each attempt: enumerate device sessions for `recipient_uuid`, drop the
+/// `excluded_device_id` if any (used by sync to skip self), encrypt the
+/// padded Content for each remaining device, submit them all in one PUT.
+/// 409/410 update the local session set; the next iteration's enumeration
+/// picks up the changes naturally.
 ///
-/// If the enumeration is empty (fresh recipient — never received from), we
-/// fall back to the device_id carried in `recipient_addr`. The 409
-/// round-trip will then add any missing devices.
-pub(crate) fn submit_with_retry_generic<S, I, D>(
-    plaintext: &str,
+/// Returns Ok(true) on a successful submission, Ok(false) when the device
+/// set is empty after exclusion (sync path's "no other devices" outcome —
+/// non-fatal, callers may want to skip rather than retry).
+fn submit_padded_with_retry_generic<S, I, D>(
+    padded_content: &[u8],
     timestamp_ms: u64,
-    recipient_addr: &ProtocolAddress,
+    recipient_uuid: &str,
+    fallback_device_id: u32,
+    excluded_device_id: Option<u32>,
     local_addr: &ProtocolAddress,
     session_store: &mut S,
     identity_store: &mut I,
@@ -532,7 +537,7 @@ pub(crate) fn submit_with_retry_generic<S, I, D>(
     account: &AccountInfo,
     http: &mut dyn HttpClient,
     sleeper: &mut dyn FnMut(Duration),
-) -> Result<(), SendError>
+) -> Result<bool, SendError>
 where
     S: SessionStore + DeviceSessionEnum,
     I: IdentityKeyStore,
@@ -552,12 +557,32 @@ where
         }
         attempt += 1;
 
-        let mut device_ids = session_store.device_ids_for(recipient_addr.name());
+        let mut device_ids = session_store.device_ids_for(recipient_uuid);
+        if let Some(excl) = excluded_device_id {
+            device_ids.retain(|d| *d != excl);
+        }
         if device_ids.is_empty() {
-            device_ids.push(u32::from(recipient_addr.device_id()));
+            // Sync path: no other devices on own account → caller decides.
+            if excluded_device_id.is_some() {
+                return Ok(false);
+            }
+            // Recipient path: fall back to the address's device_id (fresh
+            // recipient, no sessions yet); 409 round-trip will discover
+            // others.
+            device_ids.push(fallback_device_id);
         }
 
-        let mut entities: Vec<OutgoingMessageEntity> = Vec::with_capacity(device_ids.len());
+        let recipient_addr_for_handlers = {
+            let dev = u8::try_from(fallback_device_id)
+                .map_err(|_| SendError::BadResponse(
+                    format!("fallback device id {fallback_device_id} out of range")))
+                .and_then(|d| DeviceId::new(d).map_err(|e|
+                    SendError::BadResponse(format!("DeviceId: {e:?}"))))?;
+            ProtocolAddress::new(recipient_uuid.to_string(), dev)
+        };
+
+        let mut entities: Vec<OutgoingMessageEntity> =
+            Vec::with_capacity(device_ids.len());
         for did in &device_ids {
             let dev = u8::try_from(*did)
                 .map_err(|_| SendError::BadResponse(format!("device id {did} out of range")))
@@ -566,9 +591,9 @@ where
                         SendError::BadResponse(format!("DeviceId: {e:?}"))
                     })
                 })?;
-            let dev_addr = ProtocolAddress::new(recipient_addr.name().to_string(), dev);
-            let enc = build_encrypted_message_with_stores(
-                plaintext,
+            let dev_addr = ProtocolAddress::new(recipient_uuid.to_string(), dev);
+            let enc = encrypt_padded_for_recipient(
+                padded_content,
                 timestamp_ms,
                 &dev_addr,
                 local_addr,
@@ -581,7 +606,7 @@ where
         let n_entities = entities.len();
 
         let outcome = submit_messages(
-            recipient_addr.name(),
+            recipient_uuid,
             entities,
             timestamp_ms,
             account,
@@ -594,7 +619,7 @@ where
                     attempt,
                     device_ids,
                 );
-                return Ok(());
+                return Ok(true);
             }
             AttemptDecision::Mismatch409(body) => {
                 let mm = parse_mismatch(&body)?;
@@ -605,7 +630,7 @@ where
                     n_entities,
                 );
                 handle_mismatched_devices(
-                    recipient_addr,
+                    &recipient_addr_for_handlers,
                     &mm,
                     session_store,
                     identity_store,
@@ -617,7 +642,7 @@ where
             AttemptDecision::Mismatch410(body) => {
                 let mm = parse_mismatch(&body)?;
                 log::info!("send: 410 stale={:?}", mm.stale_devices);
-                handle_stale_devices(recipient_addr, &mm, deleter);
+                handle_stale_devices(&recipient_addr_for_handlers, &mm, deleter);
             }
             AttemptDecision::Backoff => {
                 let delay = backoff(attempt);
@@ -629,8 +654,147 @@ where
     }
 }
 
+/// Recipient send path: thin wrapper over `submit_padded_with_retry_generic`
+/// that builds DataMessage Content bytes from plaintext. Returns Ok(()) on
+/// success.
+pub(crate) fn submit_with_retry_generic<S, I, D>(
+    plaintext: &str,
+    timestamp_ms: u64,
+    recipient_addr: &ProtocolAddress,
+    local_addr: &ProtocolAddress,
+    session_store: &mut S,
+    identity_store: &mut I,
+    deleter: &mut D,
+    account: &AccountInfo,
+    http: &mut dyn HttpClient,
+    sleeper: &mut dyn FnMut(Duration),
+) -> Result<(), SendError>
+where
+    S: SessionStore + DeviceSessionEnum,
+    I: IdentityKeyStore,
+    D: SessionDeleter,
+{
+    let padded = build_padded_data_message_content(plaintext, timestamp_ms);
+    let _delivered = submit_padded_with_retry_generic(
+        &padded,
+        timestamp_ms,
+        recipient_addr.name(),
+        u32::from(recipient_addr.device_id()),
+        None,
+        local_addr,
+        session_store,
+        identity_store,
+        deleter,
+        account,
+        http,
+        sleeper,
+    )?;
+    Ok(())
+}
+
+/// Sync transcript path: builds a SyncMessage::Sent wrapping the original
+/// DataMessage and fans it out to every device of the sender's own account
+/// EXCLUDING the sending device. Returns Ok(()) whether or not anything was
+/// actually delivered (no other devices = nothing to do).
+///
+/// If we have no sessions to other devices of own account, performs an
+/// upfront device discovery via `GET /v2/keys/{own_uuid}/*` and establishes
+/// sessions for the discovered devices. Without this step, the first send
+/// from a fresh-linked secondary would always have an empty fan-out — the
+/// 409 mechanism can establish missing devices but only if the request body
+/// already contains entities for at least one device, which we can't
+/// produce without a session.
+pub(crate) fn submit_sync_transcript_generic<S, I, D>(
+    plaintext: &str,
+    recipient_uuid: &str,
+    timestamp_ms: u64,
+    own_uuid: &str,
+    own_device_id: u32,
+    local_addr: &ProtocolAddress,
+    session_store: &mut S,
+    identity_store: &mut I,
+    deleter: &mut D,
+    account: &AccountInfo,
+    http: &mut dyn HttpClient,
+    sleeper: &mut dyn FnMut(Duration),
+) -> Result<(), SendError>
+where
+    S: SessionStore + DeviceSessionEnum,
+    I: IdentityKeyStore,
+    D: SessionDeleter,
+{
+    // Up-front device discovery if we have no sessions to other devices.
+    let known: Vec<u32> = session_store
+        .device_ids_for(own_uuid)
+        .into_iter()
+        .filter(|d| *d != own_device_id)
+        .collect();
+    if known.is_empty() {
+        match discover_and_establish_account_devices(
+            own_uuid,
+            Some(own_device_id),
+            session_store,
+            identity_store,
+            account,
+            http,
+        ) {
+            Ok(established) if established.is_empty() => {
+                log::info!(
+                    "sync: discovery returned no other devices for {}; transcript skipped",
+                    own_uuid,
+                );
+                return Ok(());
+            }
+            Ok(established) => {
+                log::info!(
+                    "sync: discovered + established sessions for own devices {:?}",
+                    established,
+                );
+            }
+            Err(e) => {
+                log::warn!(
+                    "sync: device discovery failed: {:?} — transcript skipped",
+                    e,
+                );
+                return Ok(());
+            }
+        }
+    }
+
+    let padded = build_padded_sync_transcript_content(
+        recipient_uuid,
+        plaintext,
+        timestamp_ms,
+    );
+    let delivered = submit_padded_with_retry_generic(
+        &padded,
+        timestamp_ms,
+        own_uuid,
+        // Fallback isn't reachable on the sync path — when the device set
+        // is empty after exclusion we early-return `false` rather than
+        // submit. The fallback value here is just a placeholder.
+        own_device_id,
+        Some(own_device_id),
+        local_addr,
+        session_store,
+        identity_store,
+        deleter,
+        account,
+        http,
+        sleeper,
+    )?;
+    if delivered {
+        log::info!("sync: transcript delivered to own-account devices");
+    } else {
+        log::info!("sync: no other devices on own account; transcript skipped");
+    }
+    Ok(())
+}
+
 /// Production retry-loop driver: uses the concrete pddb-backed stores and
-/// `std::thread::sleep` for backoff.
+/// `std::thread::sleep` for backoff. Sends the recipient DataMessage AND,
+/// on success, fans out a SyncMessage::Sent transcript to the sender's own
+/// other devices. Sync transcript failure is non-fatal.
 pub(crate) fn submit_with_retry_with_stores(
     plaintext: &str,
     timestamp_ms: u64,
@@ -658,6 +822,7 @@ pub(crate) fn submit_with_retry_with_stores(
     pddb_del.try_mount();
     let mut deleter = PddbDeleter { pddb: pddb_del };
     let mut sleeper = |d: Duration| std::thread::sleep(d);
+
     submit_with_retry_generic(
         plaintext,
         timestamp_ms,
@@ -669,7 +834,30 @@ pub(crate) fn submit_with_retry_with_stores(
         account,
         http,
         &mut sleeper,
-    )
+    )?;
+
+    // Recipient PUT succeeded. Fan out the sync transcript to our own
+    // account's other devices. Failure here is non-fatal: the recipient
+    // already has the message, the sender's primary just won't see it
+    // mirrored to its outgoing thread.
+    let sync_result = submit_sync_transcript_generic(
+        plaintext,
+        recipient_addr.name(),
+        timestamp_ms,
+        &account.aci_service_id,
+        account.device_id,
+        local_addr,
+        session_store,
+        identity_store,
+        &mut deleter,
+        account,
+        http,
+        &mut sleeper,
+    );
+    if let Err(e) = sync_result {
+        log::warn!("sync: transcript failed (non-fatal): {e:?}");
+    }
+    Ok(())
 }
 
 fn backoff(attempt: u32) -> Duration {
@@ -754,6 +942,76 @@ where
         }
     }
     Ok(())
+}
+
+/// Proactively fetch prekey bundles for all devices of an account and
+/// establish sessions for each (excluding `excluded_device_id`, used by the
+/// sync transcript path to skip the sender's own device).
+///
+/// Used at the start of the sync transcript path when we have no sessions
+/// to any of our own account's other devices yet — the 409 mechanism would
+/// otherwise establish them lazily, but Signal-Server requires the request
+/// body to address at least the primary device, so we need at least one
+/// session up front.
+///
+/// Endpoint: `GET /v2/keys/{uuid}/*` returns a PreKeyResponse with one
+/// DeviceEntry per registered device of the account.
+fn discover_and_establish_account_devices<S, I>(
+    account_uuid: &str,
+    excluded_device_id: Option<u32>,
+    session_store: &mut S,
+    identity_store: &mut I,
+    account: &AccountInfo,
+    http: &mut dyn HttpClient,
+) -> Result<Vec<u32>, SendError>
+where
+    S: SessionStore,
+    I: IdentityKeyStore,
+{
+    let url = {
+        let mut u = account.chat_base_url()?;
+        u.set_path(&format!("/v2/keys/{}/*", account_uuid));
+        u
+    };
+    let auth = account.basic_auth();
+    let resp = http
+        .get_json(url.as_str(), &auth)
+        .map_err(|e| SendError::Transport(format!("discover devices: {e}")))?;
+    match resp.status {
+        200 => {}
+        401 => return Err(SendError::AuthFailed),
+        404 => return Ok(Vec::new()),
+        other => return Err(SendError::Unexpected(other)),
+    }
+
+    let pre: PreKeyResponse = serde_json::from_slice(&resp.body)
+        .map_err(|e| SendError::BadResponse(format!("discover prekey parse: {e}")))?;
+
+    let identity_key = decode_identity_key(&pre.identity_key)?;
+    let mut established = Vec::new();
+    for entry in &pre.devices {
+        if Some(entry.device_id) == excluded_device_id {
+            continue;
+        }
+        let bundle = build_prekey_bundle(entry, identity_key)?;
+        let dev_addr = device_protocol_address(account_uuid, entry.device_id)
+            .ok_or_else(|| SendError::BadResponse(format!(
+                "device id {} out of range", entry.device_id)))?;
+        let mut rng = rand::rngs::OsRng.unwrap_err();
+        block_on(process_prekey_bundle(
+            &dev_addr,
+            session_store,
+            identity_store,
+            &bundle,
+            std::time::SystemTime::now(),
+            &mut rng,
+        ))
+        .map_err(|e| SendError::BadResponse(format!(
+            "discover process_prekey_bundle for {}/{}: {e:?}",
+            account_uuid, entry.device_id)))?;
+        established.push(entry.device_id);
+    }
+    Ok(established)
 }
 
 fn process_one_prekey_bundle<S, I>(
@@ -1922,7 +2180,7 @@ mod tests {
 
         fn get_json(&mut self, url: &str, _auth: &str) -> io::Result<HttpResponse> {
             *self.get_count.borrow_mut() += 1;
-            // /v2/keys/{uuid}/{device_id}
+            // /v2/keys/{uuid}/{device_id|*}
             let tail = url
                 .split("/v2/keys/")
                 .nth(1)
@@ -1931,11 +2189,46 @@ mod tests {
             let uuid = parts
                 .next()
                 .ok_or_else(|| io::Error::other("missing uuid"))?;
-            let dev: u32 = parts
+            let selector = parts
                 .next()
-                .and_then(|s| s.parse().ok())
-                .ok_or_else(|| io::Error::other("missing device_id"))?;
+                .ok_or_else(|| io::Error::other("missing device selector"))?;
 
+            // Wildcard returns the merged response across all registered
+            // devices (one PreKeyResponse with multiple `devices` entries).
+            // Mirrors Signal-Server's GET /v2/keys/{uuid}/* shape.
+            if selector == "*" {
+                let devices = self.registered.get(uuid);
+                let entries = match devices {
+                    Some(v) if !v.is_empty() => v,
+                    _ => return Ok(HttpResponse { status: 404, body: vec![] }),
+                };
+                let mut all_entries: Vec<serde_json::Value> = Vec::new();
+                let mut identity_key_b64: Option<String> = None;
+                for d in entries {
+                    let resp: serde_json::Value =
+                        serde_json::from_slice(&d.prekey_response_body).unwrap();
+                    if identity_key_b64.is_none() {
+                        identity_key_b64 = resp["identityKey"].as_str().map(|s| s.to_string());
+                    }
+                    if let Some(devs) = resp["devices"].as_array() {
+                        for entry in devs {
+                            all_entries.push(entry.clone());
+                        }
+                    }
+                }
+                let body = serde_json::json!({
+                    "identityKey": identity_key_b64.unwrap_or_default(),
+                    "devices": all_entries,
+                });
+                return Ok(HttpResponse {
+                    status: 200,
+                    body: serde_json::to_vec(&body).unwrap(),
+                });
+            }
+
+            let dev: u32 = selector
+                .parse()
+                .map_err(|_| io::Error::other(format!("bad selector {selector}")))?;
             let bundle = self
                 .registered
                 .get(uuid)
@@ -2160,5 +2453,144 @@ mod tests {
             1,
             "expected exactly one delete for bob/2 on 410"
         );
+    }
+
+    // ---- sync transcript fan-out (Phase A v7) ------------------------------
+
+    /// `submit_sync_transcript_generic` must:
+    ///   - target the sender's own UUID (PUT URL contains own_uuid)
+    ///   - exclude own_device_id from the fan-out device set
+    ///   - include all OTHER devices of own UUID
+    ///   - emit a SyncMessage Content (not a DataMessage Content) inside
+    ///     each per-device ciphertext
+    /// We can't decrypt the ciphertext through MockHttp, but we can verify
+    /// the device set the PUT addresses, and that the only PUT is to
+    /// own_uuid (no recipient PUT).
+    #[test]
+    fn sync_transcript_fans_out_to_own_other_devices() {
+        // Alice (own account) has a session with herself's other device 7.
+        // Sender device_id = 1 (the linked secondary doing the send).
+        // Own account UUID = "alice-uuid". Recipient is irrelevant in this
+        // direct test (we drive submit_sync_transcript_generic directly).
+        let mut alice = fresh_lib_store();
+        let alice_self_other_addr =
+            ProtocolAddress::new("alice-uuid".into(), DeviceId::new(7).unwrap());
+
+        // Pre-establish Alice → Alice/7 session (own-account other device).
+        let mut alice_other = fresh_lib_store();
+        let alice_other_bundle =
+            make_bundle(&mut alice_other, DeviceId::new(7).unwrap());
+        let mut rng = OsRng.unwrap_err();
+        block_on(libsignal_protocol::process_prekey_bundle(
+            &alice_self_other_addr,
+            &mut alice.session_store,
+            &mut alice.identity_store,
+            &alice_other_bundle,
+            std::time::SystemTime::now(),
+            &mut rng,
+        ))
+        .unwrap();
+
+        let local_addr =
+            ProtocolAddress::new("alice-uuid".into(), DeviceId::new(1).unwrap());
+
+        let mut http = StatefulMockHttp::new();
+        // Real Signal-Server excludes the requesting device from its 409
+        // "mismatched devices" calculation when receiving a sync transcript
+        // PUT, so the mock only registers the OTHER devices of own UUID.
+        let alice_identity =
+            block_on(alice.get_identity_key_pair()).unwrap();
+        let dev7 = make_registered_device(
+            &mut fresh_lib_store(),
+            &alice_identity,
+            7,
+        );
+        http.register_device("alice-uuid", dev7);
+
+        let mut deleter = CountingDeleter::new();
+        let mut sleeper = no_sleep();
+        let mut tracker = TrackingSessionStore::new(
+            &mut alice.session_store,
+            &[("alice-uuid", 7)],
+        );
+
+        let r = submit_sync_transcript_generic(
+            "hello sync",
+            "bob-uuid",          // recipient UUID echoed inside the transcript
+            1_700_000_000_000,
+            "alice-uuid",        // own UUID (PUT target)
+            1,                   // own device id (excluded)
+            &local_addr,
+            &mut tracker,
+            &mut alice.identity_store,
+            &mut deleter,
+            &fake_account(),
+            &mut http,
+            &mut sleeper,
+        );
+        if let Err(e) = &r {
+            panic!("submit_sync_transcript_generic failed: {:?}", e);
+        }
+
+        // Exactly one PUT, to alice-uuid, addressing only device 7.
+        assert_eq!(*http.put_count.borrow(), 1);
+        let put = http.last_put_body.borrow().clone().expect("a PUT happened");
+        let req: serde_json::Value = serde_json::from_slice(&put).unwrap();
+        let device_ids: Vec<u32> = req["messages"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .map(|e| e["destinationDeviceId"].as_u64().unwrap() as u32)
+            .collect();
+        assert_eq!(
+            device_ids,
+            vec![7u32],
+            "sync PUT must address own-other devices excluding self"
+        );
+    }
+
+    /// When the sender's own account has no devices other than the sender
+    /// itself, the sync transcript path must short-circuit without any PUT.
+    #[test]
+    fn sync_transcript_skipped_when_own_account_has_no_other_devices() {
+        let mut alice = fresh_lib_store();
+        let local_addr =
+            ProtocolAddress::new("alice-uuid".into(), DeviceId::new(1).unwrap());
+
+        // No prior sessions for alice-uuid in the tracker.
+        let mut tracker = TrackingSessionStore::new(
+            &mut alice.session_store,
+            &[],
+        );
+
+        let mut http = StatefulMockHttp::new();
+        // Server registration is irrelevant — we shouldn't reach it.
+        let mut deleter = CountingDeleter::new();
+        let mut sleeper = no_sleep();
+
+        let r = submit_sync_transcript_generic(
+            "hello sync",
+            "bob-uuid",
+            1_700_000_000_000,
+            "alice-uuid",
+            1,
+            &local_addr,
+            &mut tracker,
+            &mut alice.identity_store,
+            &mut deleter,
+            &fake_account(),
+            &mut http,
+            &mut sleeper,
+        );
+        if let Err(e) = &r {
+            panic!("expected Ok (no-op), got {:?}", e);
+        }
+        assert_eq!(*http.put_count.borrow(), 0,
+            "no PUT expected when own account has no other devices");
+        // One GET expected: the up-front device discovery
+        // /v2/keys/{own_uuid}/* which the empty-mock returns 404 for,
+        // causing the sync path to skip without further requests.
+        assert_eq!(*http.get_count.borrow(), 1,
+            "one discovery GET expected, no further requests");
     }
 }


### PR DESCRIPTION
# Implement multi-device send fan-out and sync transcripts

This PR completes the 1:1 outbound message path. After merging,
sending from `xous-signal-client` (a linked secondary device on
the user's account) is visible to:

1. The intended recipient on every device of the recipient's account.
2. The sender's own other devices, via sync transcripts.

End-to-end verified on real Signal infrastructure: a message
typed on the Precursor emulator appears on the recipient's phone
as an incoming message, and on the sender's primary phone as an
outgoing message — same as if the sender had typed it on their
phone.

## Protocol references

This implementation follows Signal's
[Sesame algorithm](https://signal.org/docs/specifications/sesame/)
for multi-device session management. The relevant pieces:

- **Sending Messages**. For each known device session of the
  recipient, encrypt the plaintext separately under that device's
  session and submit the resulting ciphertexts as a single
  `messages: Vec<OutgoingMessageEntity>` body.
- **Mismatched Devices** (HTTP 409). Server returns
  `missingDevices` and `extraDevices` arrays when the body's
  device list doesn't match the recipient's actual device list.
  The sender fetches prekey bundles for missing devices,
  establishes sessions, drops sessions for extras, and retries.
- **Stale Devices** (HTTP 410). Server returns `staleDevices`
  when a `destinationRegistrationId` is stale. The sender drops
  the affected session and retries.
- **Sync transcripts**. Any linked device that sends a message
  also emits a `SyncMessage::Sent` envelope to its own account's
  UUID, which Signal's server fans out to the sender's other
  devices.

The wire field tags come from Signal's canonical
[`SignalService.proto`](https://github.com/whisperfish/libsignal-service-rs/blob/main/protobuf/SignalService.proto)
(the same proto Signal-Android, Signal-iOS, and signal-cli
generate from). Hand-rolling the prost definitions made it easy
to drift; a previous bug in this branch had `DataMessage.timestamp`
at field 5 (`expireTimer`) instead of canonical 7. Recipients
silently dropped those messages at content validation.

## End-to-end send pipeline

1. Keyboard event → IPC → `SigchatOp::Post` handler.
2. The UI captures plaintext and a single `u64` timestamp; that
   single timestamp value is reused throughout this entire flow
   in five distinct locations on the wire (see *Verification*).
3. `build_padded_data_message_content` builds a
   `Content { dataMessage }` proto with `body` at tag 1 and
   `timestamp` at tag 7, then applies Signal's padding (`0x80`
   marker + zero fill to the next multiple of 160).
4. `submit_padded_with_retry_generic` enumerates every device
   for which a session exists for the recipient UUID, encrypts
   the padded Content separately for each device via libsignal's
   session cipher, and submits all of them in a single
   `PUT /v1/messages/{recipient_uuid}` body.
5. On 409, `handle_mismatched_devices` fetches prekey bundles
   for `missingDevices` (via `GET /v2/keys/{recipient}/{device}`),
   processes each bundle to establish a session, drops sessions
   for `extraDevices`, and re-enters the loop. The next encryption
   pass picks up the new session set automatically because
   `DeviceSessionEnum::device_ids_for` reads from the same store
   that `process_prekey_bundle` writes to.
6. On 410, `handle_stale_devices` drops the listed sessions.
7. On a successful recipient PUT, `submit_sync_transcript_generic`
   builds a `Content { syncMessage { sent } }` wrapping the
   recipient UUID, the timestamp, and a copy of the original
   `DataMessage` proto. If we have no sessions to other devices
   of our own account (the first-send-from-fresh-link case),
   `discover_and_establish_account_devices` performs an upfront
   `GET /v2/keys/{own_uuid}/*` to learn the device set and
   establish sessions. The sync transcript is then submitted via
   `PUT /v1/messages/{own_uuid}` with the sender's own device
   excluded from the fan-out. Sync transcript failure is
   non-fatal: the recipient already has the message, so a missing
   transcript is a UX gap (sender's own primary won't see the
   message in its outgoing thread) rather than a delivery
   failure.

## Bugs fixed during this work

This send path was the conclusion of a multi-session arc. Each
bug was caught by real-server testing, not by unit tests. They
are documented here so future maintainers know the failure modes
to look for in similar protocol work.

### Unpadded base64 in prekey-bundle responses

Signal-Server uses Java's `Base64.getEncoder().withoutPadding()`
for prekey-bundle response fields (signed prekey signature,
identity key, public keys). Our decoder used Rust's
`STANDARD` engine which requires padding, so the very first 409
retry on a multi-device recipient failed with `Invalid padding`
before any session could be established with a missing device.

Fix: a `PERMISSIVE` engine configured with
`DecodePaddingMode::Indifferent` for server-response decodes;
encoding is unchanged.

### Single-device retry on 409

The retry loop encrypted only for the original recipient device,
producing the same single-device body on every retry. The server
kept returning the same 409 because the missing device was never
actually added to the request body.

Fix: a `DeviceSessionEnum` trait, with the production
`PddbSessionStore` impl reading sessions for a UUID from the PDDB
session dict by key prefix. The retry loop enumerates the device
set on every iteration, encrypts for every device, and emits one
`OutgoingMessageEntity` per device.

### `DataMessage.timestamp` at the wrong proto tag

The hand-rolled DataMessage encoder emitted `timestamp` at proto
field 5, which is `expireTimer` (uint32), instead of canonical
field 7 (uint64). Signal-Server's `EnvelopeContentValidator`
rejects DataMessages without a timestamp at field 7;
Signal-Android and Signal-iOS silently drop the message at
post-decryption Content validation. signal-cli logs the
validation failure ("Invalid content! [DataMessage] Missing
timestamp!") which surfaced the bug.

Fix: corrected the proto tag in both the send-side (DataMessage
construction) and the symmetric receive-side (DataMessage
parsing).

### No sync transcripts

Closed by this PR. See the *End-to-end send pipeline* section
above.

## Test infrastructure

`StatefulMockHttp` (in `manager::send::tests`) simulates the
slice of Signal-Server we exercise: an account UUID has a
registered device set, and PUT `/v1/messages` returns 409 with
the symmetric difference between the registered set and the
device set in the body. GET `/v2/keys/{uuid}/{device}` returns
the registered prekey response for that device, and the wildcard
form `/v2/keys/{uuid}/*` returns a merged response over all
registered devices.

The earlier `MockHttp` (canned response queue) failed to catch
the single-device-retry bug because mocks didn't reflect real
server behaviour — the same body got the same canned response
forever. The stateful mock catches that failure mode and any
future variant deterministically.

Two new tests on top of the existing 63:

- `sync_transcript_fans_out_to_own_other_devices`: pre-establish
  a session for own UUID device 7; verify exactly one PUT to
  `own_uuid` addressing only device 7 (sender device 1 excluded).
- `sync_transcript_skipped_when_own_account_has_no_other_devices`:
  verify the discovery GET returns 404, the sync path
  short-circuits, and no further requests are made.

## Verification

Wire bytes from a real send (`XSCDEBUG_DUMP=1` env var enables
an `outgoing.rs` diagnostic that hex-dumps Content protobufs
pre-encrypt, padded plaintext, and ciphertexts to
`/tmp/xsc-wire-dump.txt`). `protoc --decode_raw` of the captured
Content bytes from this branch's verification scan:

Recipient PUT to `fcfd84ca-...`:

```
1 {                                # Content.dataMessage
  1: "It works!"
  7: 1777274495655                # canonical timestamp tag
}
```

Sync PUT to own UUID:

```
2 {                                # Content.syncMessage
  1 {                              # SyncMessage.sent
    2: 1777274495655              # Sent.timestamp
    3 {                            # Sent.message (inner DataMessage)
      1: "It works!"
      7: 1777274495655
    }
    7: "fcfd84ca-..."             # Sent.destinationServiceId
  }
}
```

The single timestamp value `1777274495655` flows through five
locations consistently: the recipient DataMessage (tag 7), the
recipient sealed-sender envelope timestamp, the recipient PUT
body's top-level timestamp, the `SyncMessage::Sent.timestamp`
(tag 2), and the inner wrapped DataMessage timestamp inside the
sync (tag 7).

Both phones confirmed by the user:

- The recipient's primary device shows `It works!` as an
  incoming message in the thread for the sender.
- The sender's primary device shows `It works!` as an outgoing
  message in the thread for the recipient (delivered via the
  sync transcript).

## Open follow-ups (not in this PR)

- **Receive-side audit**. The send-path bugs above were caught
  by carefully comparing wire bytes against canonical Signal
  protos. The receive path has not had the same audit and may
  have latent gaps. Worth a similar audit at some point.
- **Identity-key change UX**. If a recipient's identity key
  changes, libsignal returns `UntrustedIdentity` on encrypt.
  Currently surfaces as a generic `SendError`; should be a
  user-visible "safety number changed" prompt per Signal's UX
  guidelines.
- **Prekey replenishment**. When inbound `PreKey` messages
  consume one-time prekeys from the server-side stock, we don't
  replenish them. Eventually new contacts cannot establish
  sessions. Tracked from Task 7.
- **`DataMessage.profileKey`**. Real Signal clients set this on
  every outbound DataMessage. The current send path doesn't.
  Some recipient-side rendering paths gate on its presence.
  Currently works without it for the test case; may surface
  as missed-rendering in some scenarios.
- **Library-migration question**. This implementation is
  hand-rolled against `libsignal-protocol`. Three of the four
  bugs fixed in this arc (base64, single-device retry, proto
  tag) are bugs that
  [`whisperfish/libsignal-service-rs`](https://github.com/whisperfish/libsignal-service-rs)
  cannot have, because it generates protos from canonical
  `.proto` sources via `prost-build` and inherits the multi-
  device fan-out logic from upstream. Worth a separate session
  to assess whether the cost of hand-rolling on top of
  `libsignal-protocol` is worth the dependency-tree control vs
  pulling in `libsignal-service-rs` as a dependency. Out of
  scope here.

## Files touched in this branch

```
 src/manager/outgoing.rs | 151 ++++++++++++---
 src/manager/send.rs     | 494 +++++++++++++++++++++++++++++++++++++++++++++---
 2 files changed, 587 insertions(+), 58 deletions(-)
```

## Attribution

Multi-device fan-out and sync transcript patterns adapted from
[`whisperfish/libsignal-service-rs`](https://github.com/whisperfish/libsignal-service-rs)
`sender.rs::create_encrypted_messages` and `send_sync_message`
(AGPL-3.0). Our codebase is dual-licensed Apache-2.0 OR
AGPL-3.0; the AGPL side covers the adaptation.

Per the `xous-core` AI-assisted contribution policy: this PR
was developed with help from an AI coding agent. The two send-
path commits and the sync transcript implementation are
explicitly trailered "Generated with an AI agent." in their
commit messages. The author vouches for the quality, license
compliance, and utility of the submission.
