### PR TITLE
Project documentation consolidation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,3 +33,8 @@ MANIFEST
 
 # Test environment with real account values
 tools/.env
+
+# PDDB snapshots contain real session keys and identity material.
+# Never commit.
+**/pddb-images/*.bin
+**/pddb-images/*.snapshot

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,212 @@
+# AGENTS.md
+
+Cold-start context for AI agents and human contributors working on
+`xous-signal-client`.
+
+## What this is
+
+A Signal Protocol messaging client for [Precursor](https://www.crowdsupply.com/sutajio-kosagi/precursor)
+running on [Xous OS](https://github.com/betrusted-io/xous-core).
+1:1 messaging end-to-end against live `chat.signal.org`. Hand-rolled
+libsignal-protocol orchestration (PDDB-backed protocol stores, worker-
+thread WebSocket, multi-device fan-out, sync transcripts).
+
+This project shares its in-tree app name with `sigchat`, a Xous chat-app
+skeleton in `xous-core`'s app registry. `xous-signal-client` began as
+a fork of that skeleton and diverged completely as the Signal protocol
+implementation grew; the `sigchat` name is preserved internally to
+xous-core to avoid changes to the app-allowlist, but the codebases are
+now distinct. Practical implications:
+
+- The `cargo xtask run sigchat:...` invocation, the
+  `gam::APP_NAME_SIGCHAT` constant, the `SigchatOp::*` IPC opcode set,
+  and the `sigchat.*` PDDB dict prefixes (e.g., `sigchat.account`,
+  `sigchat.session`) all use that in-tree app name. Do not rename
+  these in this repo.
+- Sister-folder working notes at `~/workdir/xous-signal-client-notes/`
+  preserve the project's debugging history, bug arcs, and
+  lessons-learned. Read `activeContext.md` there at the start of a
+  new session.
+
+## Required environment
+
+- Rust toolchain. Hosted-mode builds work with stable 1.95+. Cross-
+  compile to `riscv32imac-unknown-xous-elf` uses xous-core's xtask
+  toolchain (downloads a betrusted-io fork of the Rust compiler with
+  pre-built std).
+
+- **`xous-core` checked out on branch `feat/05-curve25519-dalek-4.1.3`.**
+  This is non-negotiable — other branches pin `root-keys` to
+  `curve25519-dalek = "=4.1.2"` which conflicts with this project's
+  requirement of 4.1.3. The branch carries several local patches; see
+  `~/workdir/xous-signal-client-notes/techContext.md` for the patch
+  table with upstream-PR tracking.
+
+- **`signal-cli`** for end-to-end testing. Linked to one of the test
+  accounts as a secondary device.
+
+- **Working `tools/.env`** (gitignored). Copy `tools/test-env.example`
+  and edit. Real account values never go in committed files.
+
+- **PDDB snapshot** of a linked account at
+  `~/workdir/xous-core/tools/pddb-images/hosted-linked-display-verified.bin`
+  (or equivalent post-prekey-persistence-fix snapshot).
+
+  **Warning:** the `.bin` snapshot files contain real session keys
+  and identity material. They are gitignored; do not commit them or
+  paste their contents into any external system (issue tracker, chat,
+  log). Treat them as sensitive credential material.
+
+## Build
+
+```bash
+# Hosted (for tests + scan automation)
+cd ~/workdir/xous-signal-client
+cargo build --release --features hosted
+
+# Cross-compile to the device target
+cargo build --release --target=riscv32imac-unknown-xous-elf \
+    --bin xous-signal-client --features precursor
+```
+
+`hosted` and `precursor` are mutually exclusive. `hosted` activates IPC
+stubs for testing on Linux; `precursor` activates the real hardware
+configuration.
+
+The `hosted` feature must **omit** `gam/hosted` — forwarding it causes
+an infinite `register_ux: lend_mut` loop (IPC format mismatch).
+
+## Run hosted
+
+```bash
+cd ~/workdir/xous-core
+cargo xtask run sigchat:../xous-signal-client/target/release/xous-signal-client
+# Note: uses `sigchat:` xtask alias — xous-signal-client is registered
+# in xous-core's app-allowlist under that name (see "What this is").
+```
+
+## Testing
+
+Three test families exist; see `tests/README.md` for full
+documentation.
+
+- `cargo test --features hosted` — fast Rust unit tests
+- `./tools/run-all-tests.sh` — full orchestrator (Rust + hosted
+  E2E + memory footprint), with `KNOWN_FAIL` status surfacing
+  documented protocol gaps without blocking
+- `./tools/measure-renode.sh` — runtime memory measurement under
+  Renode hardware emulation. Renode simulates the Precursor RV32
+  target; this is the path for hardware-style testing without a
+  physical device. State of Renode infrastructure is documented
+  in `tests/README.md`.
+
+Hosted mode is the primary iteration loop. Renode is the gate
+before declaring something works on hardware-equivalent.
+
+`KNOWN_FAIL` (exit 87 from `scan-send.sh`) is non-blocking; see
+`tests/known-issues.md`.
+
+For methodology, read `tests/README.md`. Six principles from the
+Phase A debugging arc are codified there.
+
+## Diagnostic instrumentation
+
+Two env vars enable detailed logging without affecting production logs:
+
+- `XSCDEBUG_DUMP=1` — wire-byte capture in `outgoing.rs` →
+  `/tmp/xsc-wire-dump.txt`. Read via `tools/decode-wire.sh`.
+- `XSCDEBUG_RECV=1` — `[recv-debug]` log line in `main_ws.rs` showing
+  body, author, timestamp on inbound messages.
+
+Both default to off; production logs remain body-free.
+
+## Never do
+
+- **Never push to `betrusted-io/*`.** All git operations target
+  `tunnell/*`. Upstream PRs are a human decision.
+- **Never commit real account data.** No phone numbers, no UUIDs, no
+  test-message strings that have appeared in prior sessions. Use
+  placeholders (`+15550100`, all-zero UUID) in any file outside
+  `tools/.env`.
+- **Never commit a PDDB snapshot.** They contain session keys and
+  identity material. The `.gitignore` covers `**/pddb-images/*.bin`
+  and `**/pddb-images/*.snapshot`.
+- **Never add brand attribution in commit trailers.** Convention:
+  `Generated with an AI agent.` + `Signed-off-by:` (DCO).
+- **Never run destructive git commands without per-command approval.**
+  Force-push only with `--force-with-lease` and only with explicit
+  authorization for the specific operation.
+- **Never declare success based on log lines alone.** The "200 OK / post
+  sent / receipt envelope" pattern is the project's textbook anti-pattern.
+  Verification requires the three-legged stool: wire bytes + recipient
+  parse + user-visible. See `tests/README.md` Principle 3 and
+  `~/workdir/xous-signal-client-notes/lessons-learned.md`.
+
+## Reporting protocol
+
+Each non-trivial session produces:
+- **A session report** (markdown, plain prose, no marketing voice)
+  describing what changed, what was verified, what was deferred,
+  what's open. Archived in
+  `~/workdir/xous-signal-client-notes/_archive/REPORTS/` following the
+  convention `YYYY-MM-DD-<topic>.md` for chronological sortability.
+
+These are working notes, not part of this repo.
+
+## Maintenance contract
+
+Documentation in this repository is maintained as part of code
+changes, not as a separate effort. Every session that lands a
+change is responsible for keeping documentation aligned with
+the code:
+
+1. **Code changes that affect public behavior** must update
+   `CHANGELOG.md` under `[Unreleased]` in the same PR.
+2. **Architectural changes** (new modules, changed module
+   boundaries, new dependencies, changed data flow) must update
+   `ARCHITECTURE.md` and add or supersede an ADR in
+   `docs/decisions/` in the same PR.
+3. **Bug fixes that resolve issues documented in
+   `tests/known-issues.md` or
+   `xous-signal-client-notes/bug-arcs/`** must update those documents
+   to reflect the resolution in the same PR.
+4. **Test changes** must keep `tests/README.md` accurate (test
+   counts, family descriptions, KNOWN_FAIL state).
+5. **Build / dependency changes** must update the relevant
+   sections of this file (AGENTS.md) and `techContext.md` in the
+   notes folder.
+6. **Every session ends with `./tools/run-all-tests.sh`
+   reporting green** (PASS or SKIPPED for each family;
+   KNOWN_FAIL is acceptable for documented issues).
+
+The check at the end of each session is: did the docs change
+in step with the code, or did the code drift away from what the
+docs describe? If the latter, fix it before committing.
+
+## Documentation
+
+- **AGENTS.md** (this file) — cold-start context.
+- **README.md** — for human readers; brief project description, build
+  instructions, contribution path.
+- **ARCHITECTURE.md** — bird's-eye view of major modules.
+- **CHANGELOG.md** — what's shipped (Keep a Changelog format).
+- **docs/decisions/** — architectural decision records (MADR format,
+  immutable, append-only).
+- **tests/README.md** — testing methodology + six principles.
+- **tests/known-issues.md** — KNOWN_FAIL items with debugging starting
+  points.
+
+For institutional memory (bug arcs, lessons, things tried, debugging
+history), see the sister local directory
+`~/workdir/xous-signal-client-notes/`.
+
+## Quick reference — repo state at consolidation time
+
+- Branch: `chore/consolidation` (this PR).
+- Most recent merged PR: #4 (scan-send leg-2 + KNOWN_FAIL convention).
+- Tests: 65 passing (cargo test --features hosted), with additional
+  unit tests being ported in this consolidation PR.
+- Total binary: 4.0 MiB on Xous target (intentional; ~268% of 1.5 MiB
+  hard target until Phase G size reductions land).
+- KNOWN_FAIL: B2 (signal-cli libsignal decrypt fail on post-409-retry
+  CIPHERTEXT). See `tests/known-issues.md`.

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -1,0 +1,210 @@
+# Architecture
+
+Bird's-eye view of `xous-signal-client`. For protocol-level detail and
+rationale, see `docs/decisions/`. For testing methodology, see
+`tests/README.md`.
+
+## The big picture
+
+```
+                                                             ┌──────────────┐
+                                                             │ Signal       │
+                                                             │ Server       │
+                                                             │ (chat.signal │
+                                                             │  .org)       │
+                                                             └───┬───┬──┬───┘
+                                                                 │   │  │
+                                            HTTPS (REST)         │   │  │ WSS
+                                            for prekey bundles,  │   │  │ (push)
+                                            registration, send.  │   │  │
+                                                                 ▼   │  ▼
+              xous-signal-client process                       ┌──────┴────┐
+              ┌───────────────────────────────────────────────┐│  Network  │
+              │                                                ││ TCP+TLS+WS│
+              │  main.rs                                       │└─────┬─────┘
+              │   │                                            │      │
+              │   ├── SigChat::post()                          │      │
+              │   │   (chat.cf_post_add + chat.cf_redraw)      │      │
+              │   │                                            │      │
+              │   ├── manager::send::submit_with_retry         │      │
+              │   │     fan-out, 409/410, sync transcripts ────┼──────┼─→ ureq → Xous lib/tls
+              │   │                                            │      │
+              │   ├── account.rs                               │      │
+              │   │     identity, registration, auth           │      │
+              │   │                                            │      │
+              │   └── manager_ws_server thread (private SID)   │      │
+              │         │                                      │      │
+              │         └── main_ws::run_session ──────────────┼──────┴─→ tungstenite → Xous lib/tls
+              │                  receive worker; sealed-sender,│
+              │                  PreKey/Whisper decrypt, deliv │
+              │                                                │
+              │  PddbStores (single-thread ownership)          │
+              │  ┌──────────────┬──────────────┬─────────────┐│
+              │  │ identity     │ session      │ prekey/SPK/ ││
+              │  │              │              │ Kyber       ││
+              │  └──────┬───────┴──────┬───────┴──────┬──────┘│
+              │         │              │              │       │
+              └─────────┼──────────────┼──────────────┼───────┘
+                        │              │              │
+                ┌───────▼──────────────▼──────────────▼────────┐
+                │ pddb (Protected Encrypted Key-Value Store)   │
+                │ — xous-core service —                        │
+                └──────────────────────────────────────────────┘
+
+                       ┌─────────────────────────────────────┐
+                       │ chat lib (xous-core/libs/chat)      │
+                       │ ─────────────────────────────────── │
+                       │ SigchatOp::Post handler ←── GAM     │
+                       │ cf_post_add / cf_redraw     (typed  │
+                       │                              input) │
+                       └─────────────────────────────────────┘
+```
+
+## Major modules
+
+### `src/main.rs`
+- Boot path: `SigChat::new()` → `Account::read(PDDB)` → GAM
+  registration → `Event::Focus` → `connect()` → start receive worker.
+- Handles `SigchatOp::Post` IPC from the chat lib (typed-line input).
+- Enters main loop: drains `user_post`, dispatches to `SigChat::post()`.
+
+### `src/lib.rs`
+- `SigChat::post()` performs the local echo (`chat::cf_post_add(cid,
+  "me", ts, text)` + `chat::cf_redraw(cid)`) and invokes
+  `manager::send::submit_with_retry`. Local echo is required because
+  Signal's WebSocket does not push back the sender's own messages.
+
+### `src/manager/send.rs`
+- The send pipeline. `submit_with_retry_with_stores` orchestrates
+  the recipient send + the optional sync-transcript send.
+- `submit_padded_with_retry_generic` is the fan-out core: per-iteration,
+  enumerate device IDs from `DeviceSessionEnum::device_ids_for(uuid)`,
+  encrypt the plaintext per device, submit one PUT with
+  `Vec<OutgoingMessageEntity>`. 409 / 410 handlers update the session
+  store; the next iteration's enumeration picks up changes.
+- Status mapping for HTTP 200/204/401/404/409/410/413/428/429/5xx;
+  retry policy of 3 attempts, 30s budget, backoff 500ms · 2^attempt
+  cap 4s.
+- `HttpClient` trait — production `UreqHttpClient`, tests `MockHttp` /
+  `StatefulMockHttp`.
+
+### `src/manager/outgoing.rs`
+- Per-message Content protobuf assembly, padding (ISO-7816: 0x80 +
+  zeros to multiple of 160), and per-device encrypt step.
+- Both DataMessage (recipient) and SyncMessage::Sent (own-account)
+  Content shapes are built here. Field tags follow canonical
+  `SignalService.proto`: DataMessage.body=1, .timestamp=7;
+  SyncMessage.sent=1, Sent.timestamp=2, Sent.message=3,
+  Sent.destinationServiceId=7; Content.dataMessage=1, .syncMessage=2.
+
+### `src/manager/main_ws.rs`
+- The receive worker. `run_session` loops: read one frame at a time
+  (with short read timeout to interleave with app-keepalive timer);
+  classify Binary vs Ping vs other; dispatch envelope.
+- `dispatch_envelope` branches on envelope type:
+  `ENVELOPE_UNIDENTIFIED_SENDER (6)` → `sealed_sender_decrypt_to_usmc`
+  → branch on inner type → `message_decrypt_signal` (CIPHERTEXT) or
+  `message_decrypt_prekey` (PREKEY_BUNDLE);
+  `ENVELOPE_CIPHERTEXT (1)` → direct `message_decrypt_signal`;
+  `ENVELOPE_PREKEY_BUNDLE (3)` → direct `message_decrypt_prekey`.
+- Reconnect with exponential backoff on connection drop.
+- App-layer keepalive: `GET /v1/keepalive` over the authenticated WS
+  every 55s. WS-protocol Ping every 25s.
+
+### `src/manager/ws_server.rs`
+- The provisioning WebSocket worker (separate from `main_ws`).
+  Used during device-link flow. Owns its own private `xous::SID`
+  and small opcode interface (`GetNextFrame`, `Cancel`, `SetKeepalive`,
+  `Quit`). Pattern C from the [S13] CONCURRENCY-ARCHITECTURE research
+  doc.
+
+### `src/manager/signal_ws.rs`
+- WebSocket client wrapper. tungstenite + Xous lib/tls. Handles the
+  101 Switching Protocols handshake with `Authorization: Basic`
+  header (not URL query params; see ADR 0008's bug arc reference).
+
+### `src/manager/stores.rs`
+- Five PDDB-backed stores implementing libsignal-protocol's trait
+  contracts:
+  - `PddbIdentityStore` (peer TOFU keys + own identity from
+    `sigchat.account`)
+  - `PddbPreKeyStore`, `PddbSignedPreKeyStore`, `PddbKyberPreKeyStore`
+    (one-time and signed prekeys)
+  - `PddbSessionStore` (Double Ratchet state)
+- Single-thread ownership (the receive worker owns them). No
+  Arc<Mutex>. Read-pattern `read_to_end`; write-pattern delete-then-
+  write + `pddb.sync()`.
+- `PddbSessionStore::device_ids_for(uuid)` enumerates
+  `{uuid}.{device_id}` keys for fan-out.
+
+### `src/account.rs`
+- Stored credentials, registration ID, identity key pair, profile
+  key. Backed by `sigchat.account` PDDB dict.
+
+### `src/manager.rs`, `src/manager/{rest,prekeys,account_attrs,libsignal}.rs`
+- Provisioning + linking flow. `Account::link` calls
+  `PUT /v1/devices/link` with `RegisterAsSecondaryDeviceRequest` JSON
+  body (per Signal-Android 8.9.0). On success, persists credentials +
+  prekey private keys + signed/Kyber records to PDDB.
+
+## Data flow examples
+
+### Send: typed input → recipient + sync transcript
+
+1. User types in GAM input box; presses Enter.
+2. GAM forwards line as memory message to chat lib's `gotinput_id`.
+3. chat lib forwards to sigchat's `SigchatOp::Post` opcode.
+4. `main.rs` decodes buffer, captures into `user_post`.
+5. End of message-loop iteration drains `user_post`, calls
+   `SigChat::post(text)`.
+6. `SigChat::post` runs local echo (`chat::cf_post_add` + redraw).
+7. `manager::send::submit_with_retry_with_stores` runs:
+   - Enumerate session devices for recipient UUID.
+   - Build padded Content (DataMessage with body + canonical timestamp
+     tag 7).
+   - Encrypt per device.
+   - PUT `/v1/messages/{recipient_uuid}` with
+     `messages: Vec<OutgoingMessageEntity>`.
+   - On 409, fetch missing devices' prekey bundles, process
+     `process_prekey_bundle` per missing device, retry.
+   - On success, build padded sync Content (SyncMessage::Sent inner
+     DataMessage + destinationServiceId), encrypt for own-account
+     other devices, PUT `/v1/messages/{own_uuid}`.
+
+### Receive: WS Binary frame → display
+
+1. Receive worker thread is in `run_session` loop.
+2. tungstenite reads a Binary frame.
+3. Decode `WebSocketMessage` outer wrapper; extract `Envelope`.
+4. Branch on envelope type. Common case is type 6 (sealed sender).
+5. `sealed_sender_decrypt_to_usmc` validates trust root, decodes
+   `UnidentifiedSenderMessageContent`, extracts sender + inner type.
+6. Dispatch on inner type — PreKey or Whisper. Decrypt with libsignal-
+   protocol; updates session store.
+7. Decode plaintext `Content` proto. Strip Signal application-layer
+   padding.
+8. Branch on Content.dataMessage / .syncMessage / other.
+9. For DataMessage: `chat::cf_post_add(cid, author, ts, body)` +
+   `chat::cf_redraw(cid)`. The chat server pushes the post into the
+   "default" dialogue and triggers a UI repaint.
+10. For SyncMessage::Sent: deliver to the same dialogue with the inner
+    DataMessage's body, marking it as our own outbound (received via
+    sync from another linked device).
+
+## What's NOT here (yet)
+
+- No conversation list UI; every received message goes to a single
+  "default" dialogue.
+- No outbox persistence; failed sends are local-echoed only.
+- No sealed-sender on outbound (privacy gap; envelopes go as type 1/3).
+- No DataMessage.profileKey set on outbound.
+- No automatic prekey replenishment via `PUT /v2/keys`.
+- No `mark_kyber_pre_key_used` real implementation (last-resort reuse
+  detection is a stub).
+- No session-recovery handler for libsignal envelopes
+  (RenewSessionAction / SendRetryMessageRequest).
+- No group messaging.
+
+See AGENTS.md and `docs/decisions/` for the rationale and
+`xous-signal-client-notes/activeContext.md` for the full open-follow-up
+list.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,121 @@
+# Changelog
+
+All notable changes to `xous-signal-client`. Format follows [Keep a
+Changelog](https://keepachangelog.com/en/1.1.0/).
+
+## [Unreleased]
+
+### Added
+
+- `AGENTS.md`, `ARCHITECTURE.md`, `CHANGELOG.md`: project documentation
+  derived from a consolidation pass.
+- `docs/decisions/`: 9 MADR-format ADRs covering hand-rolled libsignal-
+  protocol orchestration, canonical proto field tags, multi-device fan-
+  out, sync transcripts, testing methodology, KNOWN_FAIL convention,
+  diagnostic instrumentation, PDDB stores schema, and worker-thread
+  WebSocket pattern.
+- Maintenance contract section in `AGENTS.md` codifying the working
+  agreement that documentation is maintained as part of code changes.
+- `.gitignore` patterns for PDDB snapshot files (sensitive credential
+  material).
+- Additional unit tests for `trust_mode`, `link_state`,
+  `service_environment`, `main_ws::strip_signal_padding`, timeout
+  helpers, and the AES-CTR wrapper (ported from a parallel testing-
+  infrastructure branch).
+
+### Open known issues
+
+- **B2** — signal-cli libsignal decrypt failure on post-409-retry
+  CIPHERTEXT. KNOWN_FAIL via `tests/known-issues.md`. iOS Signal
+  unaffected; sync transcripts unaffected; receive direction unaffected.
+
+## [0.0.4] - 2026-04-27 — commit `5117925` (PR #4)
+
+### Added
+
+- `tools/scan-send.sh` now runs `signal-cli receive` after leg-1 PASS,
+  enforcing the three-legged stool of verification.
+- `KNOWN_FAIL` test status convention via exit code 87. See ADR 0006.
+- `tests/known-issues.md` — anchored doc for documented-but-unfixed
+  failures.
+
+### Changed
+
+- `tools/run-all-tests.sh` maps exit 87 → KNOWN_FAIL in summary;
+  orchestrator exits 0 (KNOWN_FAIL is non-blocking).
+- Summary column widened from `%-8s` to `%-12s` to accommodate
+  `KNOWN_FAIL` without truncation.
+
+## [0.0.3] - 2026-04-27 — commit `d67a55b` (PR #3)
+
+### Added
+
+- `tools/scan-receive.sh` (232 lines): hosted-mode receive driver.
+- `tools/test-helpers.sh::xsc_verify_linked_device` — topology
+  pre-check via `signal-cli listDevices`.
+- `XSCDEBUG_RECV=1` env-var-gated `[recv-debug]` log line in
+  `main_ws.rs::deliver_data_message` and `::deliver_sync_message`.
+- Priming pattern: scan scripts send a fresh PreKey envelope before
+  emulator boot to refresh ratchet state from PDDB snapshot.
+
+### Changed
+
+- `tools/run-all-tests.sh` orchestrator now reports four families
+  (rust, send, recv, footprint) instead of three.
+- Both scan scripts now refuse to proceed if expected linked
+  secondary (`signal-cli-test`) is absent on the verifier account.
+
+## [0.0.2] - 2026-04-27 — commit `7f9b644` (PR #2)
+
+### Added
+
+- `tests/README.md`: testing methodology + six principles
+  extracted from the Phase A bug arc.
+- `tools/scan-send.sh`: hosted-mode E2E test driver.
+- `tools/decode-wire.sh`: protobuf wire-byte decoder with canonical
+  field-tag conformance checks.
+- `tools/measure-size.sh`: thin wrapper around
+  `.github/scripts/check_size_budget.py`. Treats TOTAL-only breach as
+  PASS-WITH-NOTE per project policy.
+- `tools/measure-renode.sh`: Renode boot smoke. Detects known
+  `LiteX_Timer_32.cs(23,62)` peripheral incompatibility and reports
+  SKIPPED.
+- `tools/run-all-tests.sh`: three-family orchestrator.
+- `tools/test-env.example`; `tools/.env` gitignored.
+- README Testing section.
+
+### Changed
+
+- No production source code changed in this PR.
+
+## [0.0.1] - 2026-04-27 — commit `7786455` (PR #1)
+
+### Added — the big end-to-end-success PR
+
+- **Multi-device send fan-out** (commit `ba783ee`).
+  - `DeviceSessionEnum` trait abstraction.
+  - `PddbSessionStore::device_ids_for(uuid)` enumeration.
+  - `submit_with_retry_generic` re-encrypts per session-device per
+    iteration. Reference pattern adapted from
+    `whisperfish/libsignal-service-rs/sender.rs` (AGPL-3.0).
+- **Sync transcripts** (`SyncMessage::Sent`) for own-account secondary
+  devices (commit `0429924`).
+- **DataMessage.timestamp at canonical proto field tag 7** (commit
+  `da08f2e`). Was at tag 5 (`expireTimer`) due to manual proto
+  definition; B1 from the V5 audit. Symmetric receive-side fix at the
+  same tag.
+- **PERMISSIVE base64 decoder for prekey-bundle responses** (commit
+  `089be8e`). Server returns prekey-bundle base64 unpadded; padded
+  `STANDARD` decoder rejected.
+- **`StatefulMockHttp` test infrastructure** that simulates Signal-
+  Server's actual 409 behaviour (registered devices vs. body's
+  `messages[]`).
+- All commit trailers normalized to `Generated with an AI agent.` +
+  DCO `Signed-off-by:`. README Acknowledgement section.
+
+### Removed
+
+- `docs/research/` (internal design notes carryover from initial
+  fork): UI conversation list, memory budget, concurrency
+  architecture. Not appropriate to ship publicly. Preserved
+  internally.

--- a/README.md
+++ b/README.md
@@ -35,6 +35,13 @@ Then back in `xous-core`:
 
 (or `app-image` for hardware/Renode).
 
+## Documentation
+
+- [`AGENTS.md`](AGENTS.md) — cold-start context for agents and contributors.
+- [`ARCHITECTURE.md`](ARCHITECTURE.md) — bird's-eye view of the major modules.
+- [`CHANGELOG.md`](CHANGELOG.md) — what's shipped (Keep a Changelog format).
+- [`docs/decisions/`](docs/decisions/) — architectural decision records (MADR).
+
 ## Testing
 
 The project's testing methodology and how to run all three test

--- a/docs/decisions/0001-hand-rolled-libsignal-protocol-orchestration.md
+++ b/docs/decisions/0001-hand-rolled-libsignal-protocol-orchestration.md
@@ -1,0 +1,133 @@
+# 0001 — Hand-rolled libsignal-protocol orchestration
+
+## Status
+
+Accepted (with open architectural alternative — see Notes).
+
+## Context
+
+The project needs Signal Protocol cryptography for end-to-end-encrypted
+1:1 messaging on Precursor / Xous. Two reference implementations exist
+in Rust:
+
+- **`signalapp/libsignal`** (`rust/protocol`): the canonical Signal
+  Protocol primitives. Used by Signal-Android, Signal-Desktop, and the
+  signalapp-maintained clients. Pure Rust except for ML-KEM (via
+  `libcrux_ml_kem`). Workspace contains many crates; we'd consume only
+  `rust/protocol`.
+
+- **`whisperfish/libsignal-service-rs`** (a downstream port):
+  full-stack Signal-service implementation including REST/WS,
+  prekey management, sync transcripts, message sender/receiver,
+  account manager. Higher level. Bundles
+  `boring`/`hyper`/`tonic`/`tokio-tungstenite` for transport.
+
+The project chose the lower-level option: depend on
+`signalapp/libsignal`'s `rust/protocol` and write our own send /
+receive / store integration directly.
+
+## Decision
+
+Use `libsignal-protocol` as the cryptographic primitive layer.
+Hand-roll the transport (WebSocket + REST), the protocol-store
+backings (PDDB), and the higher-level orchestration (multi-device
+fan-out, 409/410 recovery, sealed-sender outer decode, sync
+transcripts).
+
+## Consequences
+
+### Positive
+
+- **Small dep tree.** `libsignal-service-rs/net` would pull
+  `boring`/`hyper`/`tokio` and a third TLS stack. By avoiding it, we
+  keep `tungstenite` (no rustls features; ~30 KB and crypto-free)
+  routing through Xous's existing `lib/tls`.
+- **Direct control of transport.** The Xous-idiomatic worker-thread
+  WebSocket pattern (ADR 0009) requires direct ownership of the
+  tungstenite handle. libsignal-service-rs's transport is
+  tokio-async; integration would either drag in tokio (rejected; see
+  ADR 0009) or require non-trivial adaptation.
+- **No tokio.** mtxchat's history rejected tokio explicitly ("became
+  very complex"). One std::thread::spawn-based executor fits the
+  Xous audit model.
+- **Future PQXDH and any libsignal cipher updates** cascade through
+  `libsignal-protocol` (the dep), not through a wrapper layer we have
+  to track.
+
+### Negative
+
+- **Hand-rolling protocol-level concerns is fragile.** Four bugs in
+  the V3-V7 arc (Phase A) are direct evidence:
+  - **bug arc b001** (V3): base64 padding (encode/decode mismatch
+    with Signal-Server).
+  - **bug arc b003** (V4): single-device retry vs multi-device fan-out
+    (orchestration-layer recovery logic, not a `libsignal-protocol` bug).
+  - **bug arc b004** (V5/V6, "B1"): DataMessage.timestamp at proto
+    field tag 5 instead of canonical tag 7 (manual `prost` definition
+    is an obvious target — code-generated protos cannot have
+    tag-number regressions).
+  - **bug arc b005** ("B2", currently OPEN as KNOWN_FAIL): signal-cli
+    libsignal decrypt failure on post-409-retry CIPHERTEXT. Root cause
+    not confirmed.
+- **Protocol features that "come for free" in libsignal-service-rs are
+  orchestration-layer work here.** Examples: sealed-sender on send (privacy gap;
+  not yet implemented); DataMessage.profileKey on outbound (not yet
+  set); session-recovery handler for `RenewSessionAction` /
+  `SendRetryMessageRequest` envelopes (not yet implemented); one-time
+  prekey replenishment via `PUT /v2/keys` (not yet implemented).
+- **Manual proto field-tag definitions create class of bugs that
+  prost-build-from-canonical-protos prevents** (see lessons-learned
+  principle 5: "Self-consistent encoders pass tests by being
+  bidirectionally wrong").
+
+### Neutral
+
+- The reference patterns we mirror (1:1 multi-device fan-out, 409
+  recovery, sync transcripts) come from
+  `whisperfish/libsignal-service-rs/src/sender.rs` (AGPL-3.0; same
+  license as this project). We're using the same algorithm shapes
+  rewritten for our transport/store layer.
+
+## Notes
+
+The library-migration question stays as an open architectural question.
+The honest cost-benefit:
+
+- **Migration cost:** substantial. libsignal-service-rs is async
+  (we use sync `block_on`). Dependency tree may pull crates that
+  don't compile for `riscv32imac-unknown-xous-elf` — `reqwest`,
+  `tokio-tungstenite`, `boring`. Each needs an adapter or replacement.
+  Estimated effort 3-6 sessions per the V5 audit.
+- **Migration benefit:** elimination of an entire class of wire-format
+  and protocol-orchestration bugs. Three of the four V3-V7 bugs would
+  not have shipped under a libsignal-service-rs port. The pattern
+  "find a bug, fix it, miss another" repeated four times is
+  significant evidence.
+
+Track this as an open architectural question. Re-assess when:
+- A fifth or sixth hand-rolled-protocol bug surfaces.
+- The project is ready for a multi-session refactor with high variance
+  on cross-compile risk.
+- libsignal-service-rs upstream evolves (e.g., a build-time `pqxdh`
+  feature flag for non-Signal clients per
+  `signalapp/libsignal#284`-style precedent).
+
+References to the four-bugs-in-arc evidence are intentional — this
+ADR's Consequences section is the canonical place where the cost of
+hand-rolling is recorded.
+
+## Sources
+
+- `xous-signal-client-notes/_extractions/S6.md` (PHASEA-AUDIT) — the
+  most thorough analysis.
+- `xous-signal-client-notes/_extractions/S40.md` — line-by-line diff
+  vs whisperfish/libsignal-service-rs.
+- bug arcs b001 / b003 / b004 / b005 — concrete bug-arc evidence.
+- lessons-learned.md principles 5, 6, 7, 20.
+
+## Originating commit
+
+The decision is embodied in the project's structure (which crates it
+depends on, where the sender/receiver live) rather than in any single
+commit. The orchestration code was the project's first major addition
+on top of the chat-app skeleton.

--- a/docs/decisions/0002-datamessage-canonical-proto-field-tags.md
+++ b/docs/decisions/0002-datamessage-canonical-proto-field-tags.md
@@ -1,0 +1,93 @@
+# 0002 — DataMessage proto field tags follow canonical SignalService.proto
+
+## Status
+
+Accepted.
+
+## Context
+
+The project's manual `prost` proto definitions for `Content`,
+`DataMessage`, and `SyncMessage` were originally written by hand based
+on partial reference. A bug shipped where `DataMessage.timestamp` was
+defined at proto field tag 5 (which is canonically `expireTimer:
+uint32`) instead of canonical tag 7 (`timestamp: uint64`). This is
+bug arc b004, the V5 audit's "B1".
+
+Symmetric encode/decode bug: both sides used the same
+`DataMessageProto` definition with `tag = "5"`. All 65 unit tests
+passed because both sides agreed. iPhone Signal silently dropped the
+message at content validation. signal-cli rejected with
+`InvalidMessageException` at outer decrypt (the wire format mismatch
+prevented inner content validation from running).
+
+The cause was clear once the wire bytes were captured: the project's
+manual proto definitions were authoritative inside the project, but
+disconnected from the canonical Signal `SignalService.proto`.
+
+## Decision
+
+All proto field tags in this project's encoders / decoders MUST match
+the canonical `SignalService.proto` upstream (currently visible in
+`signalapp/libsignal-service-java/src/main/protowire/SignalService.proto`
+and elsewhere in the Signal repos).
+
+Any new field added to a manual `prost` struct definition MUST be
+cross-checked against the canonical proto before merging. The
+checklist is:
+
+1. Read the canonical `.proto` for the message type.
+2. Confirm the field name and tag number match.
+3. Confirm the field type matches (e.g., `uint64` vs `uint32`).
+4. Add a `tools/decode-wire.sh` regression check if a new wire shape
+   is being introduced.
+
+## Consequences
+
+### Positive
+
+- Wire format conformance with the live Signal network. Recipients
+  (iOS Signal, Android Signal, signal-cli, libsignal-service-rs-based
+  clients) can decode the messages.
+
+### Negative
+
+- Manual proto definitions in `outgoing.rs` and `main_ws.rs` mean this
+  decision is enforced by code review and the canonical-tag-conformance
+  check in `tools/decode-wire.sh` — not by code generation. A reviewer
+  who doesn't open the canonical proto file when editing
+  `outgoing.rs::DataMessageProto` could ship the same class of bug
+  again. ADR 0001's Consequences section flags this as the strongest
+  argument for migrating to libsignal-service-rs (which is
+  prost-build-from-canonical-protos by construction).
+
+### Neutral
+
+- The decision constrains future work but does not prescribe an
+  implementation. Code-generated protos via `prost-build` would satisfy
+  this ADR; manual definitions that match canonical tags also satisfy
+  it.
+
+## Field tag reference
+
+| Message | Field | Tag | Type | Source |
+|---------|-------|-----|------|--------|
+| `Content` | `dataMessage` | 1 | `DataMessage` | SignalService.proto |
+| `Content` | `syncMessage` | 2 | `SyncMessage` | SignalService.proto |
+| `DataMessage` | `body` | 1 | string | SignalService.proto:357 |
+| `DataMessage` | `expireTimer` | 5 | uint32 | SignalService.proto:362 |
+| `DataMessage` | `timestamp` | **7** | uint64 | SignalService.proto:365 |
+| `DataMessage` | `profileKey` | 6 | bytes | SignalService.proto:364 (not yet set on outbound) |
+| `SyncMessage` | `sent` | 1 | `Sent` | SignalService.proto |
+| `SyncMessage.Sent` | `timestamp` | 2 | uint64 | SignalService.proto |
+| `SyncMessage.Sent` | `message` | 3 | DataMessage | SignalService.proto |
+| `SyncMessage.Sent` | `destinationServiceId` | 7 | string | SignalService.proto |
+
+## Sources
+
+- `xous-signal-client-notes/bug-arcs/b004-datamessage-timestamp-tag.md`
+- `xous-signal-client-notes/_extractions/S6.md` (audit), `S7.md` (fix).
+
+## Originating commit
+
+`tunnell/xous-signal-client@da08f2e` "fix(proto): DataMessage.timestamp
+at canonical tag 7" (PR #1, merged 2026-04-27).

--- a/docs/decisions/0003-multi-device-send-fan-out.md
+++ b/docs/decisions/0003-multi-device-send-fan-out.md
@@ -1,0 +1,89 @@
+# 0003 — Multi-device send fan-out via `DeviceSessionEnum`
+
+## Status
+
+Accepted.
+
+## Context
+
+Signal accounts commonly have multiple linked devices. When sending
+to such an account, the wire body of `PUT /v1/messages/{recipient_uuid}`
+must carry one ciphertext per recipient device:
+
+```json
+{
+  "messages": [
+    { "destinationDeviceId": 1, "type": 3, "content": "...", ... },
+    { "destinationDeviceId": 2, "type": 1, "content": "...", ... }
+  ],
+  ...
+}
+```
+
+Signal-Server returns `409 Mismatched Devices` if the body's
+`destinationDeviceId` set differs from the server's registered set
+for the recipient (`missingDevices`, `extraDevices`).
+
+The project's V2 implementation (`tunnell/xous-signal-client@089be8e`)
+fixed the prekey-bundle base64 decoder (bug arc b001) but the retry
+loop only re-encrypted for the original `recipient_addr` device. With
+a multi-device recipient, the loop never addressed the missing
+device, so `409 missing=[1]` fired three times to exhaustion. (Bug arc
+b003.)
+
+## Decision
+
+Implement multi-device send fan-out per the Sesame algorithm:
+
+1. **Enumerate session devices.** `PddbSessionStore::device_ids_for(uuid)`
+   parses keys of the form `{uuid}.{device_id}` from the
+   `sigchat.session` PDDB dict.
+2. **Per-iteration encrypt.** `submit_with_retry_generic` bound:
+   `S: SessionStore + DeviceSessionEnum`. Each loop iteration:
+   - enumerate device IDs from the session store
+   - encrypt the plaintext separately for each device
+   - submit one PUT with `messages: Vec<OutgoingMessageEntity>`
+3. **409 / 410 handlers update the session store** (drop stale
+   sessions for `extraDevices`/`staleDevices`; fetch and process prekey
+   bundles for `missingDevices`). The next iteration's enumeration
+   picks up the changes naturally.
+
+## Consequences
+
+### Positive
+
+- Sends to multi-device recipients work correctly on the first 409
+  recovery iteration.
+- Test scaffolding (`StatefulMockHttp`, `TrackingSessionStore`) makes
+  the multi-device behavior unit-testable: `StatefulMockHttp` simulates
+  Signal-Server's actual 409 behavior (registered devices vs body's
+  `messages[]`), so the V3 production bug deterministically reproduces
+  in unit tests under the V4 fix's regression test.
+
+### Negative
+
+- The retry loop encrypts on every iteration. This advances the sender's
+  ratchet chain counter for every attempt. The V5 audit's hypothesis H5
+  (and bug arc b005) speculates that this contributes to or aggravates
+  the post-409-retry CIPHERTEXT decrypt failure observed in signal-cli.
+  Root cause unconfirmed; tracked as KNOWN_FAIL B2.
+
+### Neutral
+
+- The pattern is adapted from
+  `whisperfish/libsignal-service-rs/src/sender.rs::create_encrypted_messages`
+  (AGPL-3.0; same license). Their `SessionStoreExt::get_sub_device_sessions`
+  corresponds to our `DeviceSessionEnum::device_ids_for`. The reference
+  does more (groups, sealed sender, sync transcripts); we mirror only
+  the 1:1 multi-device fan-out shape.
+
+## Sources
+
+- `xous-signal-client-notes/bug-arcs/b003-multi-device-fanout.md`
+- `xous-signal-client-notes/_extractions/S4.md` (gap surfaced),
+  `S5.md` (fix shipped).
+
+## Originating commit
+
+`tunnell/xous-signal-client@ba783ee` "feat(send): multi-device fan-out
+for 409/410 retry paths" (PR #1, merged 2026-04-27).

--- a/docs/decisions/0004-sync-transcripts.md
+++ b/docs/decisions/0004-sync-transcripts.md
@@ -1,0 +1,89 @@
+# 0004 — Sync transcripts (`SyncMessage::Sent`) for own-account devices
+
+## Status
+
+Accepted.
+
+## Context
+
+Signal's protocol distinguishes "outbound" messages addressed to a
+peer from "sync" messages that mirror your own outbound to your other
+linked devices. Without sync transcripts, when account A sends from
+device 2 to account B, account A's other devices (device 1, device 3,
+etc.) never see the outgoing message in their UI's sent thread.
+
+Signal's reference clients (Signal-Android, signal-cli,
+libsignal-service-rs) emit a `Content { syncMessage { sent { ... } } }`
+encrypted-and-fan-out for own-account other devices, in addition to
+the recipient send.
+
+## Decision
+
+After every successful recipient send, also build and submit a sync
+transcript:
+
+1. **Build padded sync Content** (`build_padded_sync_transcript_content`
+   in `outgoing.rs`):
+   - `Content { syncMessage = SyncMessage { sent = Sent { ... } } }`
+   - `Sent.timestamp` (tag 2) = same `timestamp_ms` as the recipient
+     send (consistency required).
+   - `Sent.message` (tag 3) = the inner `DataMessage` (same body, same
+     timestamp).
+   - `Sent.destinationServiceId` (tag 7) = the recipient UUID.
+2. **Discover own-account devices.** If no own-account sessions exist
+   yet, perform an upfront `GET /v2/keys/{own_uuid}/*` to learn the
+   device set and establish sessions
+   (`discover_and_establish_account_devices`).
+3. **Encrypt and fan-out.** Reuse `submit_padded_with_retry_generic`
+   with `excluded_device_id` set to self (so the emulator doesn't try
+   to send the sync message to itself). Submit to
+   `PUT /v1/messages/{own_uuid}`.
+4. **Sync failure is non-fatal.** If the sync send fails, log and
+   continue — the recipient send succeeded, which is the load-bearing
+   part.
+
+## Consequences
+
+### Positive
+
+- Account A's other devices see outbound messages in their sent thread,
+  matching the user expectation set by all other Signal clients.
+- User confirmed both phones display the test message during V7:
+  phone-personal as incoming, phone-work as outgoing (via the sync
+  transcript). First non-self-declared user-visible end-to-end success.
+- Wire-byte verification: the same `timestamp_ms` value flows through
+  five locations consistently (recipient DataMessage.timestamp;
+  Sent.timestamp; Sent.message.timestamp; outer SubmitMessagesRequest;
+  sealed-sender envelope timestamp). Verified via `XSCDEBUG_DUMP=1`
+  capture.
+
+### Negative
+
+- More wire bytes per send. Every send now triggers up to two PUTs
+  (recipient + sync) and per-device encryption for own-account devices.
+- The sync flow can trigger its own 409 / 410 recovery on own-account
+  devices, expanding the surface where bug arc b005 (B2) might recur.
+  In practice, the sync-to-self path has not been observed to trigger
+  B2's symptom; the bug is specific to the recipient leg.
+
+### Neutral
+
+- The implementation reuses the V4 fan-out machinery
+  (ADR 0003) by generalizing the loop to take pre-built padded Content
+  bytes plus an optional `excluded_device_id`. Code reuse is high.
+- Test infrastructure: `StatefulMockHttp` extended to support the
+  wildcard form `/v2/keys/{uuid}/*` returning a merged response over
+  all registered devices. Two new tests:
+  - `sync_transcript_fans_out_to_own_other_devices`
+  - `sync_transcript_skipped_when_own_account_has_no_other_devices`
+
+## Sources
+
+- `xous-signal-client-notes/_extractions/S8.md` (V7 — feature shipped).
+- ADR 0002 (canonical proto field tags).
+- ADR 0003 (multi-device fan-out — generalized here).
+
+## Originating commit
+
+`tunnell/xous-signal-client@0429924` (commit on `feat/sync-transcripts`
+branch; merged via PR #1, 2026-04-27).

--- a/docs/decisions/0005-testing-methodology-three-legged-stool-statefulmockhttp.md
+++ b/docs/decisions/0005-testing-methodology-three-legged-stool-statefulmockhttp.md
@@ -1,0 +1,125 @@
+# 0005 — Testing methodology: three-legged stool + StatefulMockHttp
+
+## Status
+
+Accepted. Codified in `tests/README.md`.
+
+## Context
+
+The project's V3-V7 development arc shipped multiple "end-to-end success"
+declarations that turned out to be false. V3 declared "send works"
+based on a `200 OK` log line; V4 declared "send works end-to-end" based
+on a default-valued field in a receipt envelope; V5 audited honestly
+and found two new bugs (B1 timestamp tag, B2 decrypt fail).
+
+The pattern: log lines from one component (the local app) were read
+as proof of behavior in another component (the recipient's UI). They
+were not.
+
+The project also shipped V3 with passing unit tests against a
+`ProgrammedMockHttp` that returned the same canned `409 missingDevices=[1]`
+forever. The multi-device fan-out bug (recipient_addr fixed across
+iterations) deterministically did NOT reproduce in those unit tests
+because the mock had no concept of "registered device set."
+
+These two failures share a root: tests passing while production fails.
+The methodology codified here addresses both.
+
+## Decision
+
+The project's testing methodology follows six principles, codified in
+`tests/README.md`. They are all grounded in specific bugs from the
+V3-V7 arc:
+
+### Principle 1 — Mocks must simulate real-server BEHAVIOR, not just
+### wire format.
+
+Source: V3 base64-padding bug (canned-response mocks passed; real
+Signal-Server used unpadded). V4 single-device-retry bug
+(canned-response mocks gave the same reply forever; real server tracks
+state).
+
+### Principle 2 — Self-consistent encoders pass tests by being
+### bidirectionally wrong.
+
+Source: V6 `DataMessage.timestamp` tag-5-vs-7 bug. All 65 unit tests
+passed; iPhone Signal silently dropped at content validation.
+
+### Principle 3 — The three-legged stool of verification.
+
+A send is verified only when **all three** legs hold:
+1. **Wire bytes** decode correctly per canonical SignalService.proto.
+2. **Recipient parse** (signal-cli, iOS Signal, etc.) reports `Body:`
+   for the message.
+3. **User-visible** display in the recipient's UI is confirmed.
+
+Source: V3, V4, V5 false success claims based on `200 OK` log lines.
+
+### Principle 4 — Stateful protocols need stateful test doubles.
+
+Source: V4's `StatefulMockHttp` introduction. The mock simulates
+Signal-Server's actual 409 behavior: registered devices vs body's
+`messages[]`, returns the diff. The V3 production bug becomes a
+deterministic test failure under the new fix.
+
+### Principle 5 — Diagnostic instrumentation belongs committed when
+### it has paid off twice.
+
+Source: `XSCDEBUG_DUMP=1` written-and-removed three times before being
+committed in V5. Same rule applied to `XSCDEBUG_RECV=1` in PR #3.
+See ADR 0007.
+
+### Principle 6 — Real-server testing has costs that mock testing
+### avoids.
+
+Codifies the project's intentional split: family 1 (Rust unit/integration
+tests) in CI; family 2 (hosted-mode E2E send + recv against live
+Signal-Server) local-only before PR. Real-server testing has
+rate-limit cost (signal-cli linkDevice burns provisioning codes),
+real-account state cost, and wire-byte cost.
+
+## Consequences
+
+### Positive
+
+- The "200 OK = success" anti-pattern is named (Principle 3) and made
+  structurally impossible: `tools/scan-send.sh` enforces leg-2 via
+  `signal-cli receive` after every leg-1 PASS (PR #4, ADR 0006).
+- New bugs of the V3-V4-V5 class (canned mocks not catching real-server
+  behavior) are caught at unit-test time by `StatefulMockHttp` in
+  `src/manager/send.rs::tests`.
+- Future contributors run `./tools/run-all-tests.sh` and get a
+  pass/fail/skipped report covering all four families (rust, send, recv,
+  footprint).
+
+### Negative
+
+- The orchestrator is split across hosted-mode E2E (local-only) and
+  unit tests (CI). A contributor who doesn't have the real test
+  topology (signal-cli linked, X11 display, linked PDDB snapshot) sees
+  E2E SKIPPED, not run. This is intentional; CI-runnable E2E tests
+  against real Signal-Server are out of reach.
+- The split means a bug in real-server interaction (e.g., bug arc b001
+  if it had not been found) could ship to main if no contributor runs
+  the local E2E before PR. Mitigation: scan-send.sh's leg-2 enforcement
+  + `tools/decode-wire.sh` canonical-tag check are run on every E2E
+  pass.
+
+### Neutral
+
+- The methodology is in-repo at `tests/README.md` (416 lines). The
+  bug-arc evidence is in
+  `xous-signal-client-notes/lessons-learned.md` and
+  `xous-signal-client-notes/bug-arcs/`.
+
+## Sources
+
+- `xous-signal-client-notes/_extractions/S9.md` (Phase R — codified).
+- `xous-signal-client-notes/_extractions/S6.md` (audit — surfaced the
+  declared-success pattern).
+- bug arcs b001, b003, b004, b005.
+
+## Originating commit
+
+Commit `7f9b644` (PR #2 "Repository hygiene: testing infrastructure",
+merged 2026-04-27).

--- a/docs/decisions/0006-known-fail-test-status-convention.md
+++ b/docs/decisions/0006-known-fail-test-status-convention.md
@@ -1,0 +1,133 @@
+# 0006 — `KNOWN_FAIL` test status convention
+
+## Status
+
+Accepted. Codified in `tests/known-issues.md` and `tools/scan-send.sh`.
+
+## Context
+
+The project has a documented bug (B2 — bug arc b005) — signal-cli
+libsignal decrypt failure on post-409-retry CIPHERTEXT — where leg-2
+of the three-legged stool of verification (ADR 0005) fails for one
+specific recipient (signal-cli) while leg-2 passes for other recipients
+(iOS Signal in V6/V7), and leg-1 + leg-3 (manual phone confirmation)
+pass.
+
+Three test-orchestrator behaviors are possible for this state:
+
+1. **PASS:** treat leg-1 as sufficient. This is the V3/V4/V5 declared-
+   success anti-pattern. Reject.
+2. **FAIL:** make B2 block the suite. PRs would be unable to merge until
+   B2 is root-caused and fixed. The bug isn't in any of the recently-
+   shipped code; it's a long-standing issue. Blocking PRs is overkill.
+3. **SKIPPED:** silently hide the failure. Future agents lose the
+   institutional knowledge of which leg fails. Reject.
+
+The project needed a fourth category: known-broken, surface honestly,
+don't block.
+
+## Decision
+
+Introduce a `KNOWN_FAIL` test status, conveyed via shell exit code 87
+from `tools/scan-send.sh`.
+
+### Exit-code semantics
+
+| Code | Meaning |
+|------|---------|
+| 0 | leg-1 PASS + leg-2 PASS |
+| 1 | send FAIL, or leg-2 FAIL with unexpected output |
+| 2 | Setup failure |
+| 87 | leg-1 PASS + leg-2 KNOWN_FAIL (B2-class output) |
+
+### Orchestrator behavior
+
+`tools/run-all-tests.sh`:
+
+```bash
+SEND_EXIT=0
+"$SCRIPT_DIR/scan-send.sh" || SEND_EXIT=$?
+if (( SEND_EXIT == 0 )); then
+    RESULTS[send]="PASS"
+elif (( SEND_EXIT == 87 )); then
+    RESULTS[send]="KNOWN_FAIL"
+    DETAIL[send]="B2: signal-cli libsignal decrypt fail (see tests/known-issues.md)"
+elif (( SEND_EXIT == 2 )); then
+    RESULTS[send]="SKIPPED"
+else
+    RESULTS[send]="FAIL"
+fi
+
+# ANY_FAIL check is exact string match
+ANY_FAIL=0
+for r in "${RESULTS[@]:-}"; do
+    [[ "$r" == "FAIL" ]] && ANY_FAIL=1
+done
+exit "$ANY_FAIL"
+```
+
+`KNOWN_FAIL` does not equal `FAIL` (exact string match), so the
+orchestrator exits 0 when the only non-PASS result is `KNOWN_FAIL`.
+The summary line surfaces it explicitly:
+
+```
+  send:        KNOWN_FAIL  B2: signal-cli libsignal decrypt fail (see tests/known-issues.md)
+```
+
+### Documentation
+
+`tests/known-issues.md` is anchored. Each entry has:
+
+- Status (Open as of `<date>`).
+- Symptom (verbatim error output).
+- Affected vs not-affected scope.
+- Affected leg (which of the three-legged stool).
+- Hypothesized cause.
+- Evidence.
+- Debugging starting point for a future session.
+- Cleanup instructions (what to remove from scan scripts +
+  orchestrator + this doc when the bug is fixed).
+
+## Consequences
+
+### Positive
+
+- Honest test output. Future agents see `KNOWN_FAIL` and read
+  `tests/known-issues.md`; nothing is hidden.
+- Non-blocking for unrelated PRs. Work on other parts of the codebase
+  isn't held hostage to a single open issue with a known-but-unfixed
+  cause.
+- Cleanup discipline: when the bug is fixed, the test script and the
+  orchestrator are updated alongside the fix, and the entry is deleted.
+  Stale `KNOWN_FAIL` entries can't accumulate silently because the
+  scan scripts themselves carry the grep-and-exit-87 logic that has to
+  be removed.
+
+### Negative
+
+- The bar for "KNOWN_FAIL is acceptable" must stay high. If routine
+  bugs start being declared `KNOWN_FAIL` to skip blocking, the category
+  loses its meaning. Discipline lives in code review: a `KNOWN_FAIL`
+  entry must have a documented hypothesized cause, not just "we don't
+  know why."
+- The exit code 87 is arbitrary (no convention for "test category
+  result" in shell). Documented alongside the implementation.
+
+### Neutral
+
+- The orchestrator's exact-string-match `[[ "$r" == "FAIL" ]]` is the
+  load-bearing piece. Any future change to the orchestrator must
+  preserve this exactness so KNOWN_FAIL doesn't accidentally become
+  blocking.
+
+## Sources
+
+- `xous-signal-client-notes/_extractions/S11.md` (PR #4 implementation).
+- `xous-signal-client-notes/bug-arcs/b005-signal-cli-libsignal-decrypt.md`
+  (the canonical KNOWN_FAIL bug).
+- `tests/known-issues.md` (the in-repo doc).
+
+## Originating commit
+
+`tunnell/xous-signal-client@5117925` "chore: scan-send leg-2 verify +
+KNOWN_FAIL convention for B2 (#4)" (PR #4, merged 2026-04-27).

--- a/docs/decisions/0007-diagnostic-instrumentation-committed-env-var-gated.md
+++ b/docs/decisions/0007-diagnostic-instrumentation-committed-env-var-gated.md
@@ -1,0 +1,114 @@
+# 0007 — Diagnostic instrumentation, env-var-gated, committed in-tree
+
+## Status
+
+Accepted. Two instrumented paths in production code: `XSCDEBUG_DUMP=1`
+(send-side wire-byte capture) and `XSCDEBUG_RECV=1` (receive-side
+structured `[recv-debug]` line).
+
+## Context
+
+During the V3-V5 send-debugging arc, a wire-byte capture diagnostic
+was written into `outgoing.rs`, used to identify a bug, removed
+("the diagnostic isn't part of the production code"), and re-written
+again the next session when a different bug needed similar evidence.
+This happened **three times** before the V5 audit committed it
+permanently behind an env-var gate.
+
+The V6 / V7 receive arc had a similar pattern: an ad-hoc body-content
+log line was added during diagnosis, removed before commit (production
+logs should be body-free), and re-added next session.
+
+The cost of each "remove and re-add" cycle is real: lost institutional
+memory of *why* the log line existed, lost understanding of *what
+output to expect*, and lost time in re-discovering edge cases that the
+previous diagnostic had surfaced.
+
+## Decision
+
+Diagnostic instrumentation that has paid off twice gets committed
+in-tree, behind an environment variable gate, with the format and
+location documented.
+
+The two committed instrumented paths:
+
+### `XSCDEBUG_DUMP=1` — wire-byte capture in `outgoing.rs`
+
+Appends labelled hex of the unpadded Content protobuf, padded plaintext,
+and per-device ciphertext to `/tmp/xsc-wire-dump.txt`. Read by
+`tools/decode-wire.sh` for canonical proto field-tag conformance
+checks.
+
+### `XSCDEBUG_RECV=1` — `[recv-debug]` structured log in `main_ws.rs`
+
+Adds a structured log line in `deliver_data_message` and
+`deliver_sync_message`:
+
+```rust
+if std::env::var("XSCDEBUG_RECV").as_deref() == Ok("1") {
+    log::info!(
+        "[recv-debug] kind=data author={} ts={} body_len={} body={:?}",
+        author, ts, body.len(), body
+    );
+}
+```
+
+Bodies are not logged unless this env var is set; production logs
+remain body-free. Consumed by `tools/scan-receive.sh` for marker
+round-trip verification.
+
+## The "paid off twice" rule
+
+Before adding new env-var-gated instrumentation, confirm:
+
+1. The diagnostic has been used at least twice across separate
+   debugging sessions to identify or characterize a real bug.
+2. There's a documented downstream consumer (a test script, a
+   debugging document, a tool in `tools/`).
+3. The runtime cost when the env var is not set is bounded — at most
+   one env-var check per call site per execution.
+
+If a one-off diagnostic is needed for a single session, it's still
+fine to add it locally for that session. But it doesn't get committed
+unless the second-use bar is cleared.
+
+## Consequences
+
+### Positive
+
+- Future sessions can capture wire bytes (send) or per-message body
+  content (receive) by setting an env var and running the standard
+  scan scripts. No code changes required for diagnostic work.
+- The instrumentation is auditable: anyone reading the production
+  source sees `XSCDEBUG_DUMP` / `XSCDEBUG_RECV` paths and knows what
+  they emit. There's no hidden debug-only build path.
+- Production logs stay body-free by default. The instrumentation
+  doesn't leak content unless explicitly enabled.
+
+### Negative
+
+- Slight runtime cost (one env-var check per relevant call site per
+  execution). Negligible in practice.
+- Code reads with two execution modes: with vs. without the env var.
+  Mitigated by keeping the gate at the entry of well-defined functions.
+
+### Neutral
+
+- The convention is `XSCDEBUG_*` for env-var names that affect
+  xsc-specific debug output. Reserved namespace.
+
+## Sources
+
+- `xous-signal-client-notes/_extractions/S6.md` (audit — committed
+  XSCDEBUG_DUMP after three remove-and-re-add cycles).
+- `xous-signal-client-notes/_extractions/S10.md` (PR #3 — committed
+  XSCDEBUG_RECV).
+- `xous-signal-client-notes/lessons-learned.md` principle 16.
+- ADR 0005 Principle 5.
+
+## Originating commits
+
+- `tunnell/xous-signal-client@da08f2e` (PR #1 — committed
+  `XSCDEBUG_DUMP` alongside the B1 fix).
+- `tunnell/xous-signal-client@86dca0c` (PR #3 — committed
+  `XSCDEBUG_RECV`).

--- a/docs/decisions/0008-pddb-protocol-stores-schema.md
+++ b/docs/decisions/0008-pddb-protocol-stores-schema.md
@@ -1,0 +1,123 @@
+# 0008 — PDDB-backed protocol stores schema
+
+## Status
+
+Accepted. Stores live in `src/manager/stores.rs`.
+
+## Context
+
+libsignal-protocol expresses cryptographic-state persistence via five
+async traits:
+
+- `IdentityKeyStore` — own identity + peer TOFU keys.
+- `PreKeyStore` — one-time EC prekeys.
+- `SignedPreKeyStore` — EC signed prekeys.
+- `KyberPreKeyStore` — Kyber1024 prekeys (one-time + last-resort).
+- `SessionStore` — Double Ratchet sessions (per peer per device).
+
+The project must persist these to PDDB (Xous's encrypted key-value
+store) so cryptographic state survives restart.
+
+## Decision
+
+Five PDDB dicts, one per trait store. Keys, value formats, and
+lifecycle below.
+
+### Dict shapes
+
+| Dict | Trait store | Key format | Value | Lifecycle |
+|------|-------------|------------|-------|-----------|
+| `sigchat.identity` | IdentityKeyStore (peer TOFU) | `{address.name()}.{address.device_id()}` (`.` is unambiguous separator since `name()` is a UUID) | `IdentityKey::serialize()` (33 bytes: 0x05 + 32-byte X25519) | Created on first TOFU contact; overwritten if peer key changes. |
+| `sigchat.prekey` | PreKeyStore | decimal `u32::from(PreKeyId)` | `PreKeyRecord::serialize()` | Created on prekey upload; deleted after consumption per `remove_pre_key`. |
+| `sigchat.signed_prekey` | SignedPreKeyStore | decimal `u32::from(SignedPreKeyId)` | `SignedPreKeyRecord::serialize()` | One key created at link time; rotation every ~48h is future work. |
+| `sigchat.kyber_prekey` | KyberPreKeyStore | decimal `u32::from(KyberPreKeyId)` | `KyberPreKeyRecord::serialize()` | Two keys created at link time (ACI + PNI). **Last-resort prekeys are NOT deleted** — see `mark_kyber_pre_key_used` below. |
+| `sigchat.session` | SessionStore | `{address.name()}.{address.device_id()}` | `SessionRecord::serialize()` | Created on first PREKEY_BUNDLE decrypt; updated in place on every message. Never deleted by receive path. |
+
+### Own identity is in `sigchat.account`, not `sigchat.identity`
+
+Own identity keys (private + public) are stored in the existing
+`sigchat.account` dict using the existing `aci.identity.private`,
+`aci.identity.public`, `pni.identity.private`, `pni.identity.public`,
+and `registration_id` keys. `PddbIdentityStore` holds two dict names
+(account dict + identity dict) to read own keys from one and peer keys
+from the other.
+
+### Read pattern
+
+```rust
+let mut pddb_key = pddb.get(dict, key, None, true, false, None, None::<fn()>)?;
+let mut buf = Vec::new();
+pddb_key.read_to_end(&mut buf)?;
+```
+
+`read_to_end` rather than `account.rs`'s fixed-256-byte UTF-8 buffer —
+protocol records (especially `SessionRecord`) grow over time.
+
+### Write pattern (delete-then-write)
+
+```rust
+pddb.delete_key(dict, key, None).ok();
+let mut pddb_key = pddb.get(dict, key, None, true, true, None, None::<fn()>)?;
+pddb_key.write_all(&bytes)?;
+pddb.sync().ok();
+```
+
+Mirrors the `account.rs` pattern.
+
+### `mark_kyber_pre_key_used`
+
+Currently a stub: logs and returns `Ok(())` without deleting the
+one-time key or detecting last-resort reuse. Per Signal spec: "a
+one-time Kyber pre-key should be deleted after this point. A
+last-resort pre-key should check whether the same combination was
+used before and produce an error if so."
+
+Tracked as open follow-up (see activeContext.md item 9). Affects
+Kyber-prekey-reuse detection but doesn't break the happy path.
+
+### Single-thread ownership
+
+All five stores wrap a `Pddb` handle directly. No `Arc<Mutex>`. The
+stores are owned by a single thread (the receive worker — see
+ADR 0009).
+
+## Consequences
+
+### Positive
+
+- libsignal-protocol's trait contracts are satisfied by direct PDDB
+  storage with no marshalling overhead. No base64, no UTF-8 wrappers,
+  just `serialize()` bytes.
+- Single-thread ownership avoids cross-thread mutex contention. Pattern
+  C (ADR 0009) ensures the receive worker is the only writer.
+- Dict prefix `sigchat.*` matches the in-tree app name registered
+  in xous-core's app-allowlist (see AGENTS.md "What this is").
+  PDDB snapshots persist across rebuilds without migration.
+
+### Negative
+
+- `mark_kyber_pre_key_used` stub means no last-resort reuse detection.
+  Open follow-up.
+- Five PDDB handles open per envelope dispatch (one per store). This
+  is performance polish; tracked as open follow-up but not a correctness
+  issue.
+
+### Neutral
+
+- The five-dict schema is informed by libsignal's trait surface. If
+  libsignal's traits evolve (e.g., a SenderKeyStore for groups), a new
+  dict would be added but existing dicts are stable.
+
+## Sources
+
+- `xous-signal-client-notes/_extractions/S39.md` (storage design).
+- `xous-signal-client-notes/_extractions/S41.md` (prekey persistence
+  bug fix that wired the link path to write to these dicts).
+- `xous-signal-client-notes/bug-arcs/b006-prekey-persistence.md`.
+
+## Originating commits
+
+The five-dict schema was designed during Task 7 Phase 1
+(commits `8b874be` / `d3ceb95`, originating in the chat-app
+skeleton's pre-fork history). Prekey-private-key persistence came in
+commit `39ecba7`. The schema has been stable since.

--- a/docs/decisions/0009-worker-thread-websocket-pattern-c.md
+++ b/docs/decisions/0009-worker-thread-websocket-pattern-c.md
@@ -1,0 +1,121 @@
+# 0009 — Worker-thread WebSocket: Pattern C (single-purpose SID + opcode interface)
+
+## Status
+
+Accepted. Implemented in `src/manager/main_ws.rs` (receive WS),
+`src/manager/ws_server.rs` (provisioning WS), `src/manager/signal_ws.rs`
+(WS handle wrapper).
+
+## Context
+
+Signal's protocol relies on a long-lived authenticated WebSocket for
+push delivery. The WS must:
+
+- Stay open across user UI activity (the user opening a GAM modal,
+  navigating menus, etc.).
+- Respond to server pings within a tight window.
+- Send app-layer keepalives (`GET /v1/keepalive` over the WS) at
+  ~55s intervals.
+- Receive Binary frames (envelopes) and dispatch them to decryption.
+
+GAM's modals are blocking by design (deferred-response pattern). The
+naïve approach — let the main thread own the WS, drain it between modal
+calls — breaks: the WS misses Pings, Signal-Server times out the
+connection at ~60s idle.
+
+Four candidate patterns were evaluated (see [S13]
+`xous-signal-client-notes/_extractions/S13.md`):
+
+- **Pattern A** — `Arc<Mutex<SignalWS>>`, background reader, mpsc to
+  main.
+- **Pattern B** — Ping-only timer thread, main thread still owns WS.
+- **Pattern C** — Dedicated worker thread + private `xous::SID` + opcode
+  interface.
+- **Pattern D** — Non-blocking modal pump.
+
+## Decision
+
+Adopt Pattern C. The Xous Book §7.2.3 "Asynchronous Idioms" pattern:
+
+1. **Mint a private `xous::SID`** via `xous::create_server()` for the
+   WS worker. Don't expose the main app SID to the worker. This is
+   the book idiom and an attack-surface reduction.
+2. **Spawn a worker thread** with `std::thread::spawn` that owns the
+   `tungstenite` WS handle directly. The TLS `ClientConnection` never
+   leaves this thread.
+3. **Expose a small opcode interface** to the rest of the app:
+   - `GetNextFrame` (deferred-response: main thread sends blocking;
+     worker returns when binary frame arrives, a cancel is received,
+     or WS closes)
+   - `Cancel` (main thread tells worker to unblock the above)
+   - `SetKeepalive(interval_ms)` (configures idle ping cadence)
+   - `Quit` (worker shuts down and destroys its SID)
+4. **Worker loop alternates** short-timeout WS reads (replying to
+   server pings, queueing binary frames) with `xous::try_receive_message`
+   checks and ticktimer-driven app-level keepalive sends.
+
+### Why not the alternatives
+
+- **Pattern A (Arc<Mutex<WS>>)** works in Rust's type system but TLS
+  state is now behind a Mutex. Every `lock()` is audit surface; the
+  message-passing pattern is the Xous-idiomatic alternative. Auditability
+  matters for a high-assurance device.
+- **Pattern B (ping-only timer thread + main owns WS)** is a TLS state
+  race. `rustls::ClientConnection` is `!Sync`; reading on the main
+  thread while writing a ping on the timer thread is undefined in the
+  Rust type system, and even with a Mutex it collapses to Pattern A.
+- **Pattern D (non-blocking modal pump)** would require modifying GAM's
+  `Modals` API. Out of scope for this project.
+- **tokio async runtime** is rejected per mtxchat's history: mtxcli's
+  predecessor used tokio and "became very complex." mtxchat was a
+  deliberate simplification toward Xous's threading + message-passing
+  model.
+
+## Consequences
+
+### Positive
+
+- TLS keys never cross thread boundaries except as outbound byte
+  buffers. Auditable by construction.
+- The main thread can block on GAM modals freely; the worker keeps the
+  WS alive independently.
+- Signal's ~60s idle timeout is a non-issue because the worker actively
+  sends app-level keepalives on its own schedule.
+- The narrow opcode interface is the audit surface; everything outside
+  it is unreachable by the UI side. Matches the Xous Book's "single-
+  purpose server" attack-surface-reduction pattern.
+
+### Negative
+
+- Two threads to coordinate (main + worker). The opcode protocol must
+  be carefully designed to avoid deadlocks. Done; the `GetNextFrame`
+  deferred-response + `Cancel` pair is the only blocking opcode.
+- WS-protocol Ping every 25s + app-layer keepalive every 55s = some
+  overhead. Both required by spec; not negotiable.
+
+### Neutral
+
+- The same pattern applies to the provisioning WebSocket (used during
+  device-link flow): `src/manager/ws_server.rs` is the worker; main
+  thread blocks on GAM modals while the worker drains TCP/TLS frames
+  and replies to server pings.
+- `tungstenite` is configured without `rustls-tls-*` features and
+  routes through Xous's existing `lib/tls`. No second TLS stack
+  bundled.
+
+## Sources
+
+- `xous-signal-client-notes/_extractions/S13.md` (CONCURRENCY-ARCHITECTURE
+  research doc).
+- `xous-signal-client-notes/_extractions/S38.md` (TASK-06b-ws-keepalive-IMPL —
+  the WS-worker implementation).
+- `xous-signal-client-notes/lessons-learned.md` principle 17.
+
+## Originating commits
+
+The pattern was designed during the early WS-keepalive investigation
+(see `TASK-06b-ws-keepalive-design.md` in
+`xous-signal-client-notes/_archive/REPORTS/`, 999 lines). The
+implementation shipped across several commits, including the
+`4d11ddf` WS auth fix and `42b3382` app-layer keepalive. The shape
+has been stable since.

--- a/src/account/service_environment.rs
+++ b/src/account/service_environment.rs
@@ -25,3 +25,22 @@ impl FromStr for ServiceEnvironment {
         }
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parse_display_round_trip() {
+        for s in &["Live", "Staging"] {
+            let parsed: ServiceEnvironment = s.parse().expect("known variant");
+            assert_eq!(format!("{}", parsed), *s);
+        }
+    }
+
+    #[test]
+    fn unknown_input_errors() {
+        assert!("Production".parse::<ServiceEnvironment>().is_err());
+        assert!("live".parse::<ServiceEnvironment>().is_err());
+    }
+}

--- a/src/manager/config.rs
+++ b/src/manager/config.rs
@@ -36,3 +36,33 @@ impl Config {
         &self.url
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn parse_host(s: &str) -> Host {
+        Host::parse(s).expect("valid host")
+    }
+
+    #[test]
+    fn live_environment_uses_chat_subdomain() {
+        let cfg = Config::new(parse_host("signal.org"), ServiceEnvironment::Live);
+        assert_eq!(cfg.url().as_str(), "https://chat.signal.org/");
+        assert_eq!(cfg.host().to_string(), "signal.org");
+    }
+
+    #[test]
+    fn staging_environment_uses_chat_staging_subdomain() {
+        let cfg = Config::new(parse_host("signal.org"), ServiceEnvironment::Staging);
+        assert_eq!(cfg.url().as_str(), "https://chat.staging.signal.org/");
+    }
+
+    #[test]
+    fn url_uses_https_scheme_in_both_environments() {
+        for env in &[ServiceEnvironment::Live, ServiceEnvironment::Staging] {
+            let cfg = Config::new(parse_host("signal.org"), env.clone());
+            assert_eq!(cfg.url().scheme(), "https");
+        }
+    }
+}

--- a/src/manager/group_permission.rs
+++ b/src/manager/group_permission.rs
@@ -26,3 +26,22 @@ impl FromStr for GroupPermission {
         }
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parse_display_round_trip() {
+        for s in &["EveryMember", "OnlyAdmins"] {
+            let parsed: GroupPermission = s.parse().expect("known variant");
+            assert_eq!(format!("{}", parsed), *s);
+        }
+    }
+
+    #[test]
+    fn unknown_input_errors() {
+        assert!("everymember".parse::<GroupPermission>().is_err());
+        assert!("Admins".parse::<GroupPermission>().is_err());
+    }
+}

--- a/src/manager/libsignal.rs
+++ b/src/manager/libsignal.rs
@@ -481,3 +481,76 @@ pub fn generate_identity_key_pair() -> IdentityKeyPair {
         },
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // aes256_ctr_encrypt: AES-256 in counter mode with a zero IV. Used
+    // by DeviceNameUtil to encrypt the device name for upload during
+    // device linking. Tests below pin determinism, key-length validation,
+    // and the symmetric self-decrypt invariant.
+
+    #[test]
+    fn aes256_ctr_encrypt_rejects_short_keys() {
+        let res = aes256_ctr_encrypt(&[0u8; 31], b"x");
+        assert!(res.is_err(), "31-byte key must be rejected");
+    }
+
+    #[test]
+    fn aes256_ctr_encrypt_rejects_long_keys() {
+        let res = aes256_ctr_encrypt(&[0u8; 33], b"x");
+        assert!(res.is_err(), "33-byte key must be rejected");
+    }
+
+    #[test]
+    fn aes256_ctr_encrypt_accepts_exact_32_byte_key() {
+        let res = aes256_ctr_encrypt(&[0u8; 32], b"x");
+        assert!(res.is_ok());
+    }
+
+    #[test]
+    fn aes256_ctr_encrypt_is_deterministic_for_fixed_key() {
+        let key = [0xa5u8; 32];
+        let pt = b"the quick brown fox jumps over the lazy dog";
+        let a = aes256_ctr_encrypt(&key, pt).expect("ok");
+        let b = aes256_ctr_encrypt(&key, pt).expect("ok");
+        assert_eq!(a, b, "CTR with the same key + zero IV must be deterministic");
+    }
+
+    #[test]
+    fn aes256_ctr_encrypt_preserves_plaintext_length() {
+        let key = [0u8; 32];
+        for len in [0usize, 1, 15, 16, 17, 31, 32, 33, 100] {
+            let pt = vec![0xffu8; len];
+            let ct = aes256_ctr_encrypt(&key, &pt).expect("ok");
+            assert_eq!(ct.len(), len, "len mismatch for plaintext of {len}B");
+        }
+    }
+
+    #[test]
+    fn aes256_ctr_encrypt_round_trip_self_decrypts() {
+        // CTR is its own inverse: encrypt(encrypt(p)) == p when keystream
+        // is reapplied. This verifies our implementation generates the
+        // same keystream both directions.
+        let key = [0x33u8; 32];
+        let pt = b"round-trip me, twice".to_vec();
+        let ct = aes256_ctr_encrypt(&key, &pt).expect("encrypt");
+        let pt2 = aes256_ctr_encrypt(&key, &ct).expect("decrypt");
+        assert_eq!(pt, pt2);
+    }
+
+    #[test]
+    fn aes256_ctr_keystream_advances_across_block_boundary() {
+        // For a fixed key, encrypting 17 zero bytes must NOT be 16 zero
+        // bytes followed by a repeat of byte 0 of the keystream — the
+        // counter increments and the second block uses fresh keystream.
+        let key = [0x99u8; 32];
+        let pt = vec![0u8; 17];
+        let ct = aes256_ctr_encrypt(&key, &pt).expect("ok");
+        assert_ne!(
+            ct[0], ct[16],
+            "block-2 counter byte 0 should not equal block-1 counter byte 0"
+        );
+    }
+}

--- a/src/manager/link_state.rs
+++ b/src/manager/link_state.rs
@@ -28,3 +28,23 @@ impl FromStr for LinkState {
         }
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parse_display_round_trip() {
+        for s in &["Enabled", "EnabledWithApproval", "Disabled"] {
+            let parsed: LinkState = s.parse().expect("known variant");
+            assert_eq!(format!("{}", parsed), *s);
+        }
+    }
+
+    #[test]
+    fn unknown_input_errors() {
+        assert!("enabled".parse::<LinkState>().is_err());
+        assert!("Disable".parse::<LinkState>().is_err());
+        assert!("".parse::<LinkState>().is_err());
+    }
+}

--- a/src/manager/main_ws.rs
+++ b/src/manager/main_ws.rs
@@ -710,3 +710,140 @@ fn is_timeout(e: &tungstenite::Error) -> bool {
         false
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // strip_signal_padding implements the receive-side counterpart of
+    // Signal's ISO-7816-4-style padding: a `0x80` marker byte followed by
+    // `0x00` zero fill to the next multiple of 160 bytes. The receiver
+    // pops trailing zeros, then the lone marker, leaving the original
+    // plaintext.
+
+    #[test]
+    fn strip_returns_plaintext_unchanged_when_no_padding() {
+        let plain = b"hello".to_vec();
+        assert_eq!(strip_signal_padding(plain.clone()), plain);
+    }
+
+    #[test]
+    fn strip_removes_trailing_zeros_then_marker() {
+        let mut padded = b"hi".to_vec();
+        padded.push(0x80);
+        padded.extend(std::iter::repeat(0x00).take(157));
+        assert_eq!(padded.len(), 160);
+        assert_eq!(strip_signal_padding(padded), b"hi");
+    }
+
+    #[test]
+    fn strip_handles_marker_at_end_with_no_zero_fill() {
+        let mut padded = b"x".to_vec();
+        padded.push(0x80);
+        assert_eq!(strip_signal_padding(padded), b"x");
+    }
+
+    #[test]
+    fn strip_does_not_eat_payload_zeros() {
+        let mut padded = b"a\x00b".to_vec();
+        padded.push(0x80);
+        padded.extend(std::iter::repeat(0x00).take(156));
+        assert_eq!(padded.len(), 160);
+        assert_eq!(strip_signal_padding(padded), b"a\x00b");
+    }
+
+    #[test]
+    fn strip_is_idempotent_on_already_stripped_input() {
+        let plain = b"already clean".to_vec();
+        let once = strip_signal_padding(plain.clone());
+        let twice = strip_signal_padding(once.clone());
+        assert_eq!(plain, twice);
+    }
+
+    #[test]
+    fn strip_handles_empty_input() {
+        assert!(strip_signal_padding(Vec::new()).is_empty());
+    }
+
+    // is_timeout maps tungstenite's IO error variants to a boolean used
+    // by run_session to keep the WS read loop alive across short reads.
+
+    #[test]
+    fn is_timeout_recognises_would_block() {
+        let err = tungstenite::Error::Io(io::Error::new(io::ErrorKind::WouldBlock, "x"));
+        assert!(is_timeout(&err));
+    }
+
+    #[test]
+    fn is_timeout_recognises_timed_out() {
+        let err = tungstenite::Error::Io(io::Error::new(io::ErrorKind::TimedOut, "x"));
+        assert!(is_timeout(&err));
+    }
+
+    #[test]
+    fn is_timeout_does_not_treat_unexpected_eof_as_timeout() {
+        let err = tungstenite::Error::Io(io::Error::new(io::ErrorKind::UnexpectedEof, "x"));
+        assert!(!is_timeout(&err));
+    }
+
+    #[test]
+    fn is_timeout_does_not_treat_protocol_error_as_timeout() {
+        let err = tungstenite::Error::Protocol(
+            tungstenite::error::ProtocolError::ResetWithoutClosingHandshake,
+        );
+        assert!(!is_timeout(&err));
+    }
+
+    // Self-consistent encode/decode round-trips for the proto types in
+    // this module. Catches regressions where someone changes one tag
+    // without the symmetric change. For canonical-tag conformance
+    // against real Signal-Server wire bytes, see tools/decode-wire.sh.
+
+    #[test]
+    fn content_data_message_round_trips_body_and_timestamp() {
+        let dm = DataMessageProto {
+            body: Some("hello".to_string()),
+            timestamp: Some(1_700_000_000_000),
+        };
+        let content = ContentProto {
+            data_message: Some(dm),
+            sync_message: None,
+        };
+        let mut bytes = Vec::new();
+        content.encode(&mut bytes).expect("encode");
+        let decoded = ContentProto::decode(bytes.as_slice()).expect("decode");
+        let dm = decoded.data_message.expect("data_message present");
+        assert_eq!(dm.body.as_deref(), Some("hello"));
+        assert_eq!(dm.timestamp, Some(1_700_000_000_000));
+    }
+
+    #[test]
+    fn content_sync_sent_round_trips_destination_and_inner_message() {
+        let inner_dm = DataMessageProto {
+            body: Some("sync body".to_string()),
+            timestamp: Some(1_700_000_000_000),
+        };
+        let sent = SentMessageProto {
+            destination_service_id: Some("uuid-1234".to_string()),
+            timestamp: Some(1_700_000_000_000),
+            message: Some(inner_dm),
+        };
+        let sync = SyncMessageProto { sent: Some(sent) };
+        let content = ContentProto {
+            data_message: None,
+            sync_message: Some(sync),
+        };
+        let mut bytes = Vec::new();
+        content.encode(&mut bytes).expect("encode");
+        let decoded = ContentProto::decode(bytes.as_slice()).expect("decode");
+        let sent = decoded
+            .sync_message
+            .and_then(|s| s.sent)
+            .expect("sync.sent present");
+        assert_eq!(sent.destination_service_id.as_deref(), Some("uuid-1234"));
+        assert_eq!(sent.timestamp, Some(1_700_000_000_000));
+        let inner = sent.message.expect("inner DataMessage present");
+        assert_eq!(inner.body.as_deref(), Some("sync body"));
+        assert_eq!(inner.timestamp, Some(1_700_000_000_000));
+    }
+}

--- a/src/manager/trust_mode.rs
+++ b/src/manager/trust_mode.rs
@@ -32,3 +32,30 @@ impl FromStr for TrustMode {
         }
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn display_matches_variant_name() {
+        assert_eq!(format!("{}", TrustMode::OnFirstUse), "OnFirstUse");
+        assert_eq!(format!("{}", TrustMode::Always), "Always");
+        assert_eq!(format!("{}", TrustMode::Never), "Never");
+    }
+
+    #[test]
+    fn parse_then_display_round_trips_every_variant() {
+        for s in &["OnFirstUse", "Always", "Never"] {
+            let parsed: TrustMode = s.parse().expect("known variant");
+            assert_eq!(format!("{}", parsed), *s);
+        }
+    }
+
+    #[test]
+    fn unknown_input_errors() {
+        assert!("Sometimes".parse::<TrustMode>().is_err());
+        assert!("".parse::<TrustMode>().is_err());
+        assert!("onfirstuse".parse::<TrustMode>().is_err()); // case-sensitive
+    }
+}

--- a/tools/ui-driving/README.md
+++ b/tools/ui-driving/README.md
@@ -1,0 +1,43 @@
+# tools/ui-driving/
+
+Reference scripts for driving the Xous hosted-mode minifb window via X11
+`XSendEvent`. Originally used to navigate from idle through the device-link
+flow during the early protocol-debugging arc. Preserved for Phase D
+(conversation-list UI) work where similar automation will be needed.
+
+## Scripts
+
+| Script | What it does |
+|--------|--------------|
+| `navigate_to_link.py` | Full sequence: idle → menu → App → signal → radio modal (Link) → host modal → name modal → `manager.link()`. The most complete reference for the navigation pattern. |
+| `continue_to_link.py` | Resumes navigation from the already-open radio modal (Link highlighted). Useful when a partial automation got stuck or when the flow is split across sessions. |
+| `autodrive_qr.py` | Drives idle → QR display modal. Stops at QR (does NOT scan). Watches the Xous log for the `device_link_uri:` line as success. |
+| `start_and_navigate.sh` | Orchestrator: starts Xous hosted mode, waits for full init, runs `navigate_to_link.py`. References the legacy `xous-phaseN.log` log-file convention; will need path updates before re-running. |
+
+## Status
+
+These scripts target the older sigchat-skeleton codebase's UI flow.
+Specific menu structure, modal sequences, key timing, and log-file paths
+may have drifted since they were written. Treat them as **reference
+material**, not turn-key automation. Read the script, confirm the menu
+structure and timing match current behavior, then adapt.
+
+The X11 `XSendEvent` mechanics (the bottom half of each `.py` script —
+display open, keysym lookup, send-event construction) are stable and
+reusable as-is for any GAM-driven automation.
+
+## When to use
+
+Phase D (conversation-list UI work) will likely need to drive the chat
+UI through scenarios that aren't covered by the current
+`tools/scan-send.sh` / `tools/scan-receive.sh` priming pattern. These
+scripts are the starting point: copy whichever script most closely
+matches the target scenario, adapt the navigation sequence, and reuse
+the X11 plumbing.
+
+For non-Phase-D work, the current testing infrastructure
+(`tools/run-all-tests.sh` + the priming pattern in
+`tools/scan-{send,receive}.sh`) is sufficient. UI-driving scripts here
+are deliberately not invoked from the orchestrator — they require a
+real X11 display and contain timing assumptions that aren't appropriate
+for CI.

--- a/tools/ui-driving/autodrive_qr.py
+++ b/tools/ui-driving/autodrive_qr.py
@@ -1,0 +1,173 @@
+#!/usr/bin/env python3
+"""
+Auto-drive Xous hosted-mode sigchat from idle to the QR-display modal.
+
+After boot + GAM ready, injects X11 keys to:
+  1. Open main menu, navigate to Apps → signal → focus sigchat
+  2. Confirm the Link option in the account-setup radio modal
+  3. Accept the default "xous" device name (or whatever is pre-filled)
+
+Stops at QR display (does NOT scan). Monitors the xous log for the
+`device_link_uri:` line to confirm QR was rendered.
+
+No arguments. Reads $DISPLAY (defaults to localhost:10.0).
+"""
+
+import ctypes, time, os, sys, subprocess, re
+
+DISPLAY = os.environ.get("DISPLAY", "localhost:10.0")
+
+X11 = ctypes.cdll.LoadLibrary("libX11.so.6")
+c_ulong, c_int, c_uint = ctypes.c_ulong, ctypes.c_int, ctypes.c_uint
+
+X11.XOpenDisplay.restype = ctypes.c_void_p
+X11.XOpenDisplay.argtypes = [ctypes.c_char_p]
+X11.XSync.argtypes = [ctypes.c_void_p, c_int]
+X11.XDefaultRootWindow.restype = c_ulong
+X11.XDefaultRootWindow.argtypes = [ctypes.c_void_p]
+X11.XKeysymToKeycode.restype = c_uint
+X11.XKeysymToKeycode.argtypes = [ctypes.c_void_p, c_ulong]
+X11.XFlush.argtypes = [ctypes.c_void_p]
+X11.XFetchName.restype = c_int
+X11.XFetchName.argtypes = [ctypes.c_void_p, c_ulong, ctypes.POINTER(ctypes.c_char_p)]
+X11.XQueryTree.restype = c_int
+X11.XQueryTree.argtypes = [
+    ctypes.c_void_p, c_ulong,
+    ctypes.POINTER(c_ulong), ctypes.POINTER(c_ulong),
+    ctypes.POINTER(ctypes.POINTER(c_ulong)), ctypes.POINTER(c_uint),
+]
+X11.XFree.argtypes = [ctypes.c_void_p]
+X11.XSendEvent.restype = c_int
+X11.XSendEvent.argtypes = [ctypes.c_void_p, c_ulong, c_int, c_ulong, ctypes.c_void_p]
+
+
+class XEvent(ctypes.Union):
+    class XKeyEvent(ctypes.Structure):
+        _fields_ = [
+            ("type", c_int), ("serial", c_ulong), ("send_event", c_int),
+            ("display", ctypes.c_void_p), ("window", c_ulong), ("root", c_ulong),
+            ("subwindow", c_ulong), ("time", c_ulong),
+            ("x", c_int), ("y", c_int), ("x_root", c_int), ("y_root", c_int),
+            ("state", c_uint), ("keycode", c_uint), ("same_screen", c_int),
+        ]
+    _fields_ = [("key", XKeyEvent), ("pad", ctypes.c_char * 192)]
+
+
+def find_win(dpy, root, name_b):
+    cname = ctypes.c_char_p()
+    X11.XFetchName(dpy, root, ctypes.byref(cname))
+    if cname.value and name_b in cname.value.lower():
+        return root
+    r, p, n = c_ulong(), c_ulong(), c_uint()
+    ch = ctypes.POINTER(c_ulong)()
+    if X11.XQueryTree(dpy, root, ctypes.byref(r), ctypes.byref(p), ctypes.byref(ch), ctypes.byref(n)):
+        children = [ch[i] for i in range(n.value)]
+        if n.value:
+            X11.XFree(ch)
+        for child in children:
+            w = find_win(dpy, child, name_b)
+            if w:
+                return w
+    return None
+
+
+def press(dpy, win, root, kc, wait, label):
+    ev = XEvent()
+    ev.key.type = 2  # KeyPress
+    ev.key.send_event = 1
+    ev.key.display = dpy
+    ev.key.window = win
+    ev.key.root = root
+    ev.key.keycode = kc
+    ev.key.same_screen = 1
+    X11.XSendEvent(dpy, win, 1, 1, ctypes.byref(ev))
+    X11.XFlush(dpy)
+    time.sleep(0.05)
+    ev.key.type = 3  # KeyRelease
+    X11.XSendEvent(dpy, win, 1, 2, ctypes.byref(ev))
+    X11.XFlush(dpy)
+    print(f"  [{label}] kc={kc}, wait {wait}s")
+    sys.stdout.flush()
+    time.sleep(wait)
+
+
+def main():
+    if len(sys.argv) > 1:
+        log_path = sys.argv[1]
+    else:
+        # pick the most recent autodrive log
+        import glob
+        candidates = sorted(glob.glob("/home/tunnell/workdir/scan-06b-AUTODRIVE-*.log"), reverse=True)
+        log_path = candidates[0] if candidates else None
+        if not log_path:
+            print("no AUTODRIVE log found; pass path as arg", file=sys.stderr)
+            sys.exit(1)
+
+    dpy = X11.XOpenDisplay(DISPLAY.encode())
+    if not dpy:
+        print(f"cannot open {DISPLAY}", file=sys.stderr); sys.exit(1)
+    root = X11.XDefaultRootWindow(dpy)
+
+    win = find_win(dpy, root, b"precursor")
+    if not win:
+        print("Precursor window not found", file=sys.stderr); sys.exit(1)
+    print(f"Window: {win:#x}")
+    print(f"Log:    {log_path}")
+
+    kc_home = X11.XKeysymToKeycode(dpy, 0xFF50)
+    kc_down = X11.XKeysymToKeycode(dpy, 0xFF54)
+
+    print("=== Phase A: focus sigchat ===")
+    press(dpy, win, root, kc_home, 1.5, "1. Home  → open main menu")
+    press(dpy, win, root, kc_down, 0.3, "2. Down  → cursor to Apps")
+    press(dpy, win, root, kc_home, 4.5, "3. Home  → select Apps (submenu)")
+    press(dpy, win, root, kc_down, 0.3, "4. Down  → cursor to signal")
+    press(dpy, win, root, kc_home, 8.0, "5. Home  → focus signal (radio modal)")
+
+    print("=== Phase B: confirm Link in radio modal ===")
+    # Radio modal: Link=0 selected by default; 3 Downs to OK button; Home to confirm
+    press(dpy, win, root, kc_down, 0.3, "6. Down  → 0→1 Register")
+    press(dpy, win, root, kc_down, 0.3, "7. Down  → 1→2 Offline")
+    press(dpy, win, root, kc_down, 0.3, "8. Down  → 2→3 OK button")
+    press(dpy, win, root, kc_home, 2.5, "9. Home  → confirm Link, radio closes")
+
+    print("=== Phase C: accept default device name ===")
+    # name_modal alert_builder: field pre-filled 'xous', items=[field, OK]
+    press(dpy, win, root, kc_down, 0.5, "10. Down → field 0→1 OK")
+    press(dpy, win, root, kc_home, 2.0, "11. Home → confirm 'xous', modal closes")
+
+    print("=== Phase D: wait for QR modal to render ===")
+    deadline = time.time() + 25
+    qr_seen = False
+    while time.time() < deadline:
+        try:
+            with open(log_path, "r") as f:
+                content = f.read()
+        except Exception:
+            time.sleep(0.5); continue
+        m = re.search(r"device_link_uri: (sgnl://[^ ]+)", content)
+        if m:
+            print(f"  QR rendered: {m.group(1)[:80]}...")
+            qr_seen = True
+            break
+        time.sleep(0.5)
+
+    if not qr_seen:
+        print("  QR did NOT render within 25s; check the window state")
+        sys.exit(2)
+
+    print()
+    print("=== SUCCESS — QR displayed ===")
+    print("Xous is blocked on modals.show_notification() awaiting a key press.")
+    print("The WS worker is running in parallel and will receive the envelope on scan.")
+    print()
+    print("Next step (NOT taken by this script):")
+    print("  - User scans the QR with phone; phone approves link")
+    print("  - User presses ANY KEY on the Precursor to dismiss the notification")
+    print("  - Main thread then calls wait_and_take_binary(), gets the envelope,")
+    print("    runs ProvisionMessage::decode, generates prekeys, PUTs /v1/devices/link,")
+    print("    and persists the account state.")
+
+
+if __name__ == "__main__":
+    main()

--- a/tools/ui-driving/continue_to_link.py
+++ b/tools/ui-driving/continue_to_link.py
@@ -1,0 +1,128 @@
+#!/usr/bin/env python3
+"""
+Continue navigation from radio modal (Link already marked) through to manager.link().
+
+State when this script starts:
+  - Radio modal is open, "Link" is highlighted (action_payload set), select_index=0
+  - We need to navigate to the OK button and confirm
+
+Sequence:
+  A. Radio modal OK: Down×3 (to OK button at select_index=3) + Home (confirm)
+  B. host_modal (text entry, "signal.org" pre-filled): Down + Home (to OK, confirm)
+  C. probe_host runs (~10s TLS check, no key needed)
+  D. name_modal (text entry, "xous" pre-filled): Down + Home (confirm)
+  E. manager.link() starts → WSS to Signal provisioning endpoint
+
+Uses XSendEvent (not XTestFakeKeyEvent).
+"""
+
+import ctypes, time, os, sys
+
+DISPLAY = os.environ.get("DISPLAY", "localhost:10.0")
+
+X11  = ctypes.cdll.LoadLibrary("libX11.so.6")
+c_ulong = ctypes.c_ulong; c_int = ctypes.c_int; c_uint = ctypes.c_uint
+
+X11.XOpenDisplay.restype = ctypes.c_void_p; X11.XOpenDisplay.argtypes = [ctypes.c_char_p]
+X11.XSync.argtypes = [ctypes.c_void_p, c_int]
+X11.XDefaultRootWindow.restype = c_ulong; X11.XDefaultRootWindow.argtypes = [ctypes.c_void_p]
+X11.XKeysymToKeycode.restype = c_uint; X11.XKeysymToKeycode.argtypes = [ctypes.c_void_p, c_ulong]
+X11.XGetInputFocus.argtypes = [ctypes.c_void_p, ctypes.POINTER(c_ulong), ctypes.POINTER(c_int)]
+X11.XFlush.argtypes = [ctypes.c_void_p]
+X11.XFetchName.restype = c_int; X11.XFetchName.argtypes = [ctypes.c_void_p, c_ulong, ctypes.POINTER(ctypes.c_char_p)]
+X11.XQueryTree.restype = c_int; X11.XQueryTree.argtypes = [ctypes.c_void_p, c_ulong, ctypes.POINTER(c_ulong), ctypes.POINTER(c_ulong), ctypes.POINTER(ctypes.POINTER(c_ulong)), ctypes.POINTER(c_uint)]
+X11.XFree.argtypes = [ctypes.c_void_p]
+X11.XSendEvent.restype = c_int; X11.XSendEvent.argtypes = [ctypes.c_void_p, c_ulong, c_int, c_ulong, ctypes.c_void_p]
+
+class XEvent(ctypes.Union):
+    class XKeyEvent(ctypes.Structure):
+        _fields_ = [
+            ('type', c_int), ('serial', c_ulong), ('send_event', c_int),
+            ('display', ctypes.c_void_p), ('window', c_ulong), ('root', c_ulong),
+            ('subwindow', c_ulong), ('time', c_ulong),
+            ('x', c_int), ('y', c_int), ('x_root', c_int), ('y_root', c_int),
+            ('state', c_uint), ('keycode', c_uint), ('same_screen', c_int),
+        ]
+    _fields_ = [('key', XKeyEvent), ('pad', ctypes.c_char * 192)]
+
+def find_win(dpy, root, name_b):
+    cname = ctypes.c_char_p()
+    X11.XFetchName(dpy, root, ctypes.byref(cname))
+    if cname.value and name_b in cname.value.lower():
+        return root
+    r=c_ulong(); p=c_ulong(); ch=ctypes.POINTER(c_ulong)(); n=c_uint()
+    if X11.XQueryTree(dpy, root, ctypes.byref(r), ctypes.byref(p), ctypes.byref(ch), ctypes.byref(n)):
+        children = [ch[i] for i in range(n.value)]
+        if n.value:
+            X11.XFree(ch)
+        for child in children:
+            w = find_win(dpy, child, name_b)
+            if w:
+                return w
+    return None
+
+def press(dpy, win, root, kc, wait, label):
+    ev = XEvent()
+    ev.key.type = 2          # KeyPress
+    ev.key.send_event = 1
+    ev.key.display = dpy
+    ev.key.window = win
+    ev.key.root = root
+    ev.key.subwindow = 0
+    ev.key.time = 0
+    ev.key.x = ev.key.y = ev.key.x_root = ev.key.y_root = 0
+    ev.key.state = 0
+    ev.key.keycode = kc
+    ev.key.same_screen = 1
+
+    r = X11.XSendEvent(dpy, win, 1, 1, ctypes.byref(ev))
+    X11.XFlush(dpy)
+    time.sleep(0.05)
+    ev.key.type = 3
+    X11.XSendEvent(dpy, win, 1, 2, ctypes.byref(ev))
+    X11.XFlush(dpy)
+    print(f"  [{label}] kc={kc} r={r}, waiting {wait}s ...")
+    sys.stdout.flush()
+    time.sleep(wait)
+
+def main():
+    dpy = X11.XOpenDisplay(DISPLAY.encode())
+    if not dpy:
+        print(f"ERROR: cannot open {DISPLAY}", file=sys.stderr); sys.exit(1)
+    print(f"Display: {DISPLAY}")
+
+    root = X11.XDefaultRootWindow(dpy)
+    win = find_win(dpy, root, b"precursor")
+    if not win:
+        print("ERROR: Precursor window not found", file=sys.stderr)
+        sys.exit(1)
+    print(f"Window: {win:#x}")
+
+    kc_home = X11.XKeysymToKeycode(dpy, 0xFF50)
+    kc_down = X11.XKeysymToKeycode(dpy, 0xFF54)
+
+    print("=== A. Radio modal: navigate to OK button (select_index 0→3) and confirm ===")
+    press(dpy, win, root, kc_down, 0.3, "A1. Down (select_index 0→1)")
+    press(dpy, win, root, kc_down, 0.3, "A2. Down (select_index 1→2)")
+    press(dpy, win, root, kc_down, 0.3, "A3. Down (select_index 2→3=OK)")
+    press(dpy, win, root, kc_home, 2.5, "A4. Home -> confirm Link (radio modal closes)")
+
+    print("=== B. host_modal: text entry pre-filled with 'signal.org', confirm with OK ===")
+    press(dpy, win, root, kc_down, 0.5, "B1. Down (field→OK button)")
+    press(dpy, win, root, kc_home, 12.0, "B2. Home -> confirm signal.org (wait for TLS probe ~10s)")
+
+    print("=== C. name_modal: text entry pre-filled with 'xous', confirm with OK ===")
+    press(dpy, win, root, kc_down, 0.5, "C1. Down (field→OK button)")
+    press(dpy, win, root, kc_home, 2.0, "C2. Home -> confirm device name 'xous'")
+
+    print("=== D. manager.link() should now run - WSS connection to Signal ===")
+    print("Waiting 30s for network activity...")
+    sys.stdout.flush()
+    time.sleep(30)
+
+    print("Done. Check xous-phase21.log and network connections.")
+    X11.XSync(dpy, 0)
+    os._exit(0)
+
+if __name__ == "__main__":
+    main()

--- a/tools/ui-driving/navigate_to_link.py
+++ b/tools/ui-driving/navigate_to_link.py
@@ -1,0 +1,163 @@
+#!/usr/bin/env python3
+"""
+Navigate Xous hosted mode from idle state all the way through to manager.link().
+
+Full sequence:
+  1.  Home  -> open main menu (cursor at Sleep=0)              [wait 1.5s]
+  2.  Down  -> move to App (index 1)                           [wait 0.3s]
+  3.  Home  -> select App -> App submenu (shellchat=0, signal=1, Close=2) [wait 4.5s]
+  4.  Down  -> move to signal (index 1)                        [wait 0.3s]
+  5.  Home  -> select signal -> Event::Focus -> account_setup  [wait 7.0s]
+
+  Radio modal (Link/Register/Offline), select_index starts at 0 (Link):
+  6.  Home  -> mark Link as selected (action_payload="Link")   [wait 0.3s]
+  7.  Down  -> select_index 0→1                                [wait 0.3s]
+  8.  Down  -> select_index 1→2                                [wait 0.3s]
+  9.  Down  -> select_index 2→3 (OK button)                    [wait 0.3s]
+  10. Home  -> confirm Link, modal closes                       [wait 2.5s]
+
+  host_modal (alert_builder, "signal.org" pre-filled, items=[field, OK]):
+  11. Down  -> selected item 0→1 (OK button)                   [wait 0.5s]
+  12. Home  -> confirm "signal.org", modal closes               [wait 2.0s]
+
+  [probe_host returns true immediately — patched to skip TLS check]
+
+  name_modal (alert_builder, "xous" pre-filled, items=[field, OK]):
+  13. Down  -> selected item 0→1 (OK button)                   [wait 0.5s]
+  14. Home  -> confirm device name "xous", modal closes         [wait 2.0s]
+
+  manager.link() → WSS connection to Signal provisioning endpoint:
+  15. [wait 30s, monitoring log]
+
+Uses XSendEvent (not XTestFakeKeyEvent).
+Does NOT call os._exit() — stays alive until manually stopped.
+"""
+
+import ctypes, time, os, sys
+
+DISPLAY = os.environ.get("DISPLAY", "localhost:10.0")
+LOG = "/home/tunnell/workdir/xous-phase24.log"
+
+X11  = ctypes.cdll.LoadLibrary("libX11.so.6")
+c_ulong = ctypes.c_ulong; c_int = ctypes.c_int; c_uint = ctypes.c_uint
+
+X11.XOpenDisplay.restype = ctypes.c_void_p; X11.XOpenDisplay.argtypes = [ctypes.c_char_p]
+X11.XSync.argtypes = [ctypes.c_void_p, c_int]
+X11.XDefaultRootWindow.restype = c_ulong; X11.XDefaultRootWindow.argtypes = [ctypes.c_void_p]
+X11.XKeysymToKeycode.restype = c_uint; X11.XKeysymToKeycode.argtypes = [ctypes.c_void_p, c_ulong]
+X11.XGetInputFocus.argtypes = [ctypes.c_void_p, ctypes.POINTER(c_ulong), ctypes.POINTER(c_int)]
+X11.XFlush.argtypes = [ctypes.c_void_p]
+X11.XFetchName.restype = c_int; X11.XFetchName.argtypes = [ctypes.c_void_p, c_ulong, ctypes.POINTER(ctypes.c_char_p)]
+X11.XQueryTree.restype = c_int; X11.XQueryTree.argtypes = [ctypes.c_void_p, c_ulong, ctypes.POINTER(c_ulong), ctypes.POINTER(c_ulong), ctypes.POINTER(ctypes.POINTER(c_ulong)), ctypes.POINTER(c_uint)]
+X11.XFree.argtypes = [ctypes.c_void_p]
+X11.XSendEvent.restype = c_int; X11.XSendEvent.argtypes = [ctypes.c_void_p, c_ulong, c_int, c_ulong, ctypes.c_void_p]
+
+class XEvent(ctypes.Union):
+    class XKeyEvent(ctypes.Structure):
+        _fields_ = [
+            ('type', c_int), ('serial', c_ulong), ('send_event', c_int),
+            ('display', ctypes.c_void_p), ('window', c_ulong), ('root', c_ulong),
+            ('subwindow', c_ulong), ('time', c_ulong),
+            ('x', c_int), ('y', c_int), ('x_root', c_int), ('y_root', c_int),
+            ('state', c_uint), ('keycode', c_uint), ('same_screen', c_int),
+        ]
+    _fields_ = [('key', XKeyEvent), ('pad', ctypes.c_char * 192)]
+
+def find_win(dpy, root, name_b):
+    cname = ctypes.c_char_p()
+    X11.XFetchName(dpy, root, ctypes.byref(cname))
+    if cname.value and name_b in cname.value.lower():
+        return root
+    r=c_ulong(); p=c_ulong(); ch=ctypes.POINTER(c_ulong)(); n=c_uint()
+    if X11.XQueryTree(dpy, root, ctypes.byref(r), ctypes.byref(p), ctypes.byref(ch), ctypes.byref(n)):
+        children = [ch[i] for i in range(n.value)]
+        if n.value:
+            X11.XFree(ch)
+        for child in children:
+            w = find_win(dpy, child, name_b)
+            if w:
+                return w
+    return None
+
+def press(dpy, win, root, kc, wait, label):
+    ev = XEvent()
+    ev.key.type = 2          # KeyPress
+    ev.key.send_event = 1
+    ev.key.display = dpy
+    ev.key.window = win
+    ev.key.root = root
+    ev.key.subwindow = 0
+    ev.key.time = 0
+    ev.key.x = ev.key.y = ev.key.x_root = ev.key.y_root = 0
+    ev.key.state = 0
+    ev.key.keycode = kc
+    ev.key.same_screen = 1
+
+    r = X11.XSendEvent(dpy, win, 1, 1, ctypes.byref(ev))
+    X11.XFlush(dpy)
+    time.sleep(0.05)
+    ev.key.type = 3
+    X11.XSendEvent(dpy, win, 1, 2, ctypes.byref(ev))
+    X11.XFlush(dpy)
+    print(f"  [{label}] kc={kc} r={r}, waiting {wait}s ...")
+    sys.stdout.flush()
+    time.sleep(wait)
+
+def tail_log(n=5):
+    try:
+        with open(LOG) as f:
+            lines = f.readlines()
+        for l in lines[-n:]:
+            print("  LOG:", l.rstrip())
+    except:
+        pass
+    sys.stdout.flush()
+
+def main():
+    dpy = X11.XOpenDisplay(DISPLAY.encode())
+    if not dpy:
+        print(f"ERROR: cannot open {DISPLAY}", file=sys.stderr); sys.exit(1)
+    print(f"Display: {DISPLAY}")
+
+    root = X11.XDefaultRootWindow(dpy)
+    win = find_win(dpy, root, b"precursor")
+    if not win:
+        print("ERROR: Precursor window not found", file=sys.stderr)
+        sys.exit(1)
+    print(f"Window: {win:#x}")
+
+    focused = c_ulong(0); revert = c_int(0)
+    X11.XGetInputFocus(dpy, ctypes.byref(focused), ctypes.byref(revert))
+    print(f"Focus: {focused.value:#x} (match={focused.value==win})")
+
+    kc_home = X11.XKeysymToKeycode(dpy, 0xFF50)
+    kc_down = X11.XKeysymToKeycode(dpy, 0xFF54)
+
+    print("=== Main menu navigation ===")
+    press(dpy, win, root, kc_home, 1.5, "1. Home -> open main menu")
+    press(dpy, win, root, kc_down, 0.3, "2. Down -> move to App")
+    press(dpy, win, root, kc_home, 4.5, "3. Home -> select App (wait for App submenu)")
+    press(dpy, win, root, kc_down, 0.3, "4. Down -> move to signal")
+    press(dpy, win, root, kc_home, 7.0, "5. Home -> select signal (wait for radio modal)")
+
+    print("=== Radio modal: mark Link, navigate to OK, confirm ===")
+    press(dpy, win, root, kc_home, 0.3, "6. Home -> mark Link (action_payload=Link)")
+    press(dpy, win, root, kc_down, 0.3, "7. Down -> select_index 0->1")
+    press(dpy, win, root, kc_down, 0.3, "8. Down -> select_index 1->2")
+    press(dpy, win, root, kc_down, 0.3, "9. Down -> select_index 2->3 (OK)")
+    press(dpy, win, root, kc_home, 2.5, "10. Home -> confirm Link (modal closes)")
+
+    # host_modal: "signal.org" is pre-filled; account.chat_url() prepends chat.
+    # automatically, so we just navigate to OK and confirm.
+    print("=== host_modal: confirm signal.org (Down to OK, Home to confirm) ===")
+    press(dpy, win, root, kc_down, 0.5, "11. Down -> field->OK button")
+    press(dpy, win, root, kc_home, 2.0, "12. Home -> confirm signal.org")
+
+    print("=== name_modal: confirm default device name (Down to OK, Home) ===")
+    press(dpy, win, root, kc_down, 0.5, "13. Down -> field->OK button")
+    press(dpy, win, root, kc_home, 2.0, "14. Home -> confirm device name")
+
+    print("=== QR code should now be visible — scan with Signal on your phone ===")
+
+if __name__ == "__main__":
+    main()

--- a/tools/ui-driving/start_and_navigate.sh
+++ b/tools/ui-driving/start_and_navigate.sh
@@ -1,0 +1,107 @@
+#!/bin/bash
+# Start Xous hosted mode, wait for full initialization, then navigate to sigchat Link.
+set -e
+
+WORKDIR=/home/tunnell/workdir
+XOUS_DIR=$WORKDIR/xous-core
+LOG=$WORKDIR/xous-phase20.log
+PID_FILE=$WORKDIR/xous-phase20.pid
+NAVIGATE_SCRIPT=$WORKDIR/navigate_to_link.py
+
+export DISPLAY=localhost:10.0
+
+echo "=== Starting Xous phase20 ==="
+
+# Kill any stale Xous processes
+pkill -f "xous-kernel" 2>/dev/null || true
+sleep 1
+
+# Start Xous with 600s timeout
+(cd "$XOUS_DIR" && timeout 600 cargo xtask run "sigchat:../sigchat/target/release/sigchat" >"$LOG" 2>&1) &
+XOUS_BG_PID=$!
+echo $XOUS_BG_PID > "$PID_FILE"
+echo "Xous started, bg PID=$XOUS_BG_PID, log=$LOG"
+
+# Wait for SigChat::new returned (system fully ready)
+echo "Waiting for Xous readiness..."
+WAIT=0
+while [ $WAIT -lt 120 ]; do
+    if grep -q "SigChat::new returned" "$LOG" 2>/dev/null; then
+        echo "System ready (SigChat::new returned detected at t=${WAIT}s)"
+        break
+    fi
+    sleep 2
+    WAIT=$((WAIT + 2))
+done
+
+if ! grep -q "SigChat::new returned" "$LOG" 2>/dev/null; then
+    echo "ERROR: System did not become ready within 120s"
+    tail -20 "$LOG"
+    exit 1
+fi
+
+# Extra settling time
+echo "Waiting 8s for full settlement..."
+sleep 8
+
+# Verify the Precursor window exists
+echo "Checking for Precursor window..."
+WIN=$(DISPLAY=localhost:10.0 python3 -c "
+import ctypes, sys
+X11 = ctypes.cdll.LoadLibrary('libX11.so.6')
+c_ulong = ctypes.c_ulong; c_int = ctypes.c_int; c_uint = ctypes.c_uint
+X11.XOpenDisplay.restype = ctypes.c_void_p; X11.XOpenDisplay.argtypes = [ctypes.c_char_p]
+X11.XDefaultRootWindow.restype = c_ulong; X11.XDefaultRootWindow.argtypes = [ctypes.c_void_p]
+X11.XFetchName.restype = c_int; X11.XFetchName.argtypes = [ctypes.c_void_p, c_ulong, ctypes.POINTER(ctypes.c_char_p)]
+X11.XQueryTree.restype = c_int; X11.XQueryTree.argtypes = [ctypes.c_void_p, c_ulong, ctypes.POINTER(c_ulong), ctypes.POINTER(c_ulong), ctypes.POINTER(ctypes.POINTER(c_ulong)), ctypes.POINTER(c_uint)]
+X11.XFree.argtypes = [ctypes.c_void_p]
+
+def find_win(dpy, root, name_b):
+    cname = ctypes.c_char_p()
+    X11.XFetchName(dpy, root, ctypes.byref(cname))
+    if cname.value and name_b in cname.value.lower():
+        return root
+    r=c_ulong(); p=c_ulong(); ch=ctypes.POINTER(c_ulong)(); n=c_uint()
+    if X11.XQueryTree(dpy, root, ctypes.byref(r), ctypes.byref(p), ctypes.byref(ch), ctypes.byref(n)):
+        children = [ch[i] for i in range(n.value)]
+        if n.value: X11.XFree(ch)
+        for c in children:
+            w = find_win(dpy, c, name_b)
+            if w: return w
+    return None
+
+dpy = X11.XOpenDisplay(b'localhost:10.0')
+if not dpy: sys.exit(1)
+root = X11.XDefaultRootWindow(dpy)
+w = find_win(dpy, root, b'precursor')
+if w: print(hex(w))
+" 2>/dev/null)
+
+if [ -z "$WIN" ]; then
+    echo "ERROR: Precursor window not found"
+    exit 1
+fi
+echo "Precursor window found: $WIN"
+
+# Run navigation
+echo "Starting navigation sequence..."
+DISPLAY=localhost:10.0 python3 "$NAVIGATE_SCRIPT"
+echo "Navigation complete."
+
+echo "=== Monitoring log for expected entries (60s) ==="
+WAIT=0
+while [ $WAIT -lt 60 ]; do
+    echo "--- t=${WAIT}s ---"
+    tail -5 "$LOG"
+    # Check for key success indicators
+    if grep -q "SwitchToApp\|APP_MENU\|Event::Focus\|account_setup\|Link.*provisioning\|provisioning.*WSS\|connect.*Signal" "$LOG" 2>/dev/null; then
+        echo "SUCCESS: Found navigation event in log!"
+        grep -E "SwitchToApp|APP_MENU|Event.*Focus|account_setup|provisioning|connect.*Signal|injecting key|Guttering|status:" "$LOG" | tail -30
+        break
+    fi
+    sleep 5
+    WAIT=$((WAIT + 5))
+done
+
+echo "=== Final log snapshot ==="
+tail -40 "$LOG"


### PR DESCRIPTION
Consolidates documentation derived from accumulated session
reports and working notes into a Diátaxis-shaped layout with
append-only ADRs, plus ports unit test coverage previously
developed in parallel.

## What's added

- `AGENTS.md`: agent-and-contributor cold-start context,
  including the maintenance contract for keeping docs in sync
  with code
- `ARCHITECTURE.md`: bird's-eye view of major modules
- `CHANGELOG.md`: Keep a Changelog format
- `docs/decisions/`: 9 MADR-format ADRs (append-only)
- `README.md`: updated to point to ARCHITECTURE.md and AGENTS.md
- Additional unit tests for ``trust_mode``, ``link_state``,
  ``group_permission``, ``service_environment``, ``manager::config``,
  ``main_ws::strip_signal_padding``, ``is_timeout`` helpers,
  Content/Sync proto round-trips, and the AES-CTR wrapper.
  Test count: 96 (previously 65).
- `.gitignore`: added pattern for PDDB snapshot files (sensitive
  credential material)

## Maintenance contract

A new section in ``AGENTS.md`` codifies the contract that
documentation is maintained as part of code changes, not as a
separate effort. Every session that lands a change is responsible
for keeping the relevant documentation aligned with the code in
the same PR.

## How it was verified

Every claim about code behavior, build outcome, or test result
was verified by running the relevant command before being
written. Source citations are preserved in working notes (sister
local folder, not committed) so future maintainers can audit any
specific claim.

## What's not here

Raw session reports, per-session journal entries, dated narrative
debugging logs, and test scratch outputs live in a sister local
folder rather than in this repo. They would fail the Diátaxis
test (not tutorial / how-to / reference / explanation) and
don't change with code changes.