### PR TITLE
Document B2 investigation findings (no fix yet)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,8 +26,16 @@ Changelog](https://keepachangelog.com/en/1.1.0/).
 ### Open known issues
 
 - **B2** — signal-cli libsignal decrypt failure on post-409-retry
-  CIPHERTEXT. KNOWN_FAIL via `tests/known-issues.md`. iOS Signal
-  unaffected; sync transcripts unaffected; receive direction unaffected.
+  CIPHERTEXT. KNOWN_FAIL handling stays in `tools/scan-send.sh` and
+  `tools/run-all-tests.sh`. As of the 2026-04-28 dedicated investigation,
+  the documented send-direction failure is **not currently
+  reproducible** (5/5 consecutive scan-send PASSes exercising the
+  409 retry path). The PR #4 chain-counter-advance hypothesis is
+  contradicted by the repeated successful decrypts. KNOWN_FAIL stays
+  in place because the same libsignal failure-mode string surfaced in
+  the *receive* direction during the investigation, triggered by
+  PDDB-snapshot rollback while signal-cli's session state moves
+  forward across runs. See bug arc and `tests/known-issues.md`.
 
 ## [0.0.4] - 2026-04-27 — commit `5117925` (PR #4)
 

--- a/tests/known-issues.md
+++ b/tests/known-issues.md
@@ -16,7 +16,20 @@ relevant scan script, delete the entry here, and update `tests/README.md`.
 
 ## B2 — signal-cli libsignal decrypt failure after 409-retry ciphertext {#b2-signal-cli-libsignal-decrypt-fail}
 
-**Status:** Open (as of 2026-04-27).
+**Status:** Open as KNOWN_FAIL — but **send-direction not currently
+reproducible**. As of 2026-04-28, five consecutive scan-send runs
+(all exercising the documented `409 missing=[1] → ok on attempt 2
+(devices=[1, 2])` retry path) produced `Body:` confirmation from
+signal-cli with no decrypt failure. The PR #4 hypothesis
+(409 retry advances emulator's chain past signal-cli's) is
+contradicted by these results. The KNOWN_FAIL handling stays in
+place because the 2026-04-28 investigation surfaced the same
+libsignal failure-mode string in the *receive* direction (signal-cli
+priming inbound → emulator), triggered by PDDB-snapshot rollback
+while signal-cli's session state moves forward across runs. See
+`xous-signal-client-notes/bug-arcs/b005-signal-cli-libsignal-decrypt.md`
+2026-04-28 section for the full evidence and the sharpened next
+investigation plan.
 
 **Symptom.**
 After `scan-send.sh` observes the emulator's `post: sent to ...` log line


### PR DESCRIPTION
## Summary

A dedicated 2026-04-28 investigation of B2 (signal-cli libsignal
decrypt failure on post-409-retry CIPHERTEXT, KNOWN_FAIL since PR #4)
could not reproduce the documented send-direction failure. Five
consecutive `tools/scan-send.sh` runs all exercised the documented
409 retry path and signal-cli decrypted cleanly every time.

The PR #4 chain-counter-advance hypothesis is contradicted: a
single-skip across the retry is decoded without difficulty in
repeated trials.

This PR is **docs-only**. No code changes; no KNOWN_FAIL handling
removed.

### Why KNOWN_FAIL stays

The investigation surfaced the same libsignal failure-mode string
(`InvalidMessage(Whisper, "decryption failed")`) in the *receive*
direction during scan-send's priming step. Triggering condition:
the `hosted-linked-display-verified.bin` PDDB snapshot freezes the
emulator's session for signal-cli at its 2026-04-25 state while
signal-cli's session record persists across runs. Once signal-cli
has decrypted any emulator outbound, it advances its own session
and sends subsequent inbounds as Whisper SignalMessages instead of
PreKeyMessages, which the rolled-back emulator cannot decrypt.

This is the receive-direction sibling of B2 with the same root-cause
shape. KNOWN_FAIL stays in place because the bug arc deepened rather
than closed.

### Sharpened next-investigation plan

The next session should build a test fixture that controls **both**
ends' session state per run (snapshot signal-cli's `account.db`
alongside the PDDB, or script signal-cli session deletion in
`scan-send.sh`'s priming step). With that fixture in place, B2 can
be retested deterministically; the real question is whether session
state diverges on the wire, not in the test setup.

### What changed in this PR

- `tests/known-issues.md` — B2 status updated with the 2026-04-28
  findings and a pointer to the deepened bug arc section.
- `CHANGELOG.md` — Open known issues B2 entry rewritten to reflect
  the current state.

The detailed evidence and the new receive-direction sibling section
live in `xous-signal-client-notes/bug-arcs/b005-signal-cli-libsignal-decrypt.md`
(notes repository; not in this PR).

## Test plan

- [x] Confirmed `tools/scan-send.sh` PASSes 5/5 consecutive runs after
      stabilizing the priming step (signal-cli session deletion). All
      five runs hit the documented `409 missing=[1] -> ok on attempt 2
      (devices=[1, 2])` retry path; signal-cli `Body:` confirmation in
      every run.
- [x] Confirmed the new receive-direction failure-mode string in
      `main_ws.rs` after PDDB rollback without signal-cli session
      reset.
- [ ] Reviewer: read the doc updates and the bug-arc section
      (notes repo, 2026-04-28 entry) and confirm the framing matches
      the maintenance contract.