### PR TITLE
Demo execution: right-align bubbles + env-var seam

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -99,6 +99,11 @@ documentation.
   target; this is the path for hardware-style testing without a
   physical device. State of Renode infrastructure is documented
   in `tests/README.md`.
+- `./tools/demo-prep.sh` — recording-day setup. Clears
+  signal-cli's stale sessions for the emulator's UUID
+  (B2-sibling priming-flake mitigation), restores the PDDB
+  snapshot, and warms up via `scan-receive.sh`. Run once before
+  starting a demo recording session.
 
 Hosted mode is the primary iteration loop. Renode is the gate
 before declaring something works on hardware-equivalent.
@@ -117,6 +122,12 @@ Two env vars enable detailed logging without affecting production logs:
   `/tmp/xsc-wire-dump.txt`. Read via `tools/decode-wire.sh`.
 - `XSCDEBUG_RECV=1` — `[recv-debug]` log line in `main_ws.rs` showing
   body, author, timestamp on inbound messages.
+- `XSC_DEMO_PEER_UUID` (with optional `XSC_DEMO_PEER_DEVICE_ID`,
+  default 1) — if set at startup, pre-seeds the V1 default outgoing
+  recipient so a hosted-mode session can send before first receiving.
+  Demo-only seam; production paths (real linked accounts) populate
+  the recipient via `set_current_recipient` on inbound DataMessages.
+  See `manager::outgoing::seed_demo_recipient_from_env`.
 
 Both default to off; production logs remain body-free.
 
@@ -141,6 +152,32 @@ Both default to off; production logs remain body-free.
   Verification requires the three-legged stool: wire bytes + recipient
   parse + user-visible. See `tests/README.md` Principle 3 and
   `~/workdir/xous-signal-client-notes/lessons-learned.md`.
+
+## Repository scope for git operations
+
+This project's agent has push/PR permissions only for repositories
+under `tunnell/`. Do not open PRs, issues, or push branches to
+any repository under another user/org.
+
+In particular:
+
+- `betrusted-io/xous-core` is an upstream dependency. Local patches
+  needed by this project are carried on the locally-pinned branch
+  (currently `feat/05-curve25519-dalek-4.1.3`) and tracked via PRs
+  against `tunnell/xous-core` (the project's fork). They are NOT
+  pushed to or PR'd against `betrusted-io/xous-core`.
+- The same rule applies to any other dependency repo (signal-cli,
+  libsignal, etc.) referenced during work.
+- If a change to an upstream repo seems valuable for the wider
+  project, document the rationale in
+  `xous-signal-client-notes/_open-followups/` as a candidate
+  upstream contribution. The project owner decides whether and
+  when to open the upstream PR.
+
+This rule is also enforced at the token level (the fine-grained
+PAT has no scope outside `tunnell/*`), but stating it here means
+sessions don't waste effort attempting actions that will fail at
+the API.
 
 ## Reporting protocol
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,25 @@ Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Added
 
+- `XSC_DEMO_PEER_UUID` (and optional `XSC_DEMO_PEER_DEVICE_ID`) env-var
+  seam: pre-seeds the V1 default outgoing recipient at startup so a
+  hosted-mode session can send the first message without first having
+  received one. Validates UUID format and device-id range; falls back
+  to current behavior on unset/invalid input or if a recipient is
+  already persisted in PDDB. Eight new unit tests in
+  `manager::outgoing::tests::parse_demo_peer_*`.
+- Right-aligned local-author bubbles. `main.rs` calls
+  `chat.set_author_flags("me", AuthorFlag::Right)` after `dialogue_set`
+  so outgoing local-echo bubbles render on the conventional sender
+  side. Depends on the `Chat::set_author_flags` API added to chat-lib
+  on the project's pinned `feat/05-curve25519-dalek-4.1.3` branch
+  (tracked in `xous-signal-client-notes/techContext.md` patch table).
+- `tools/demo-prep.sh`: recording-day setup script. Restores the PDDB
+  snapshot, looks up the emulator's UUID via signal-cli's `recipient`
+  table by phone number, deletes any stale `session` rows for that
+  UUID (B2-sibling priming-flake mitigation per
+  `bug-arcs/b005-signal-cli-libsignal-decrypt.md`), and runs
+  `scan-receive.sh` once to warm up a clean session.
 - `AGENTS.md`, `ARCHITECTURE.md`, `CHANGELOG.md`: project documentation
   derived from a consolidation pass.
 - `docs/decisions/`: 9 MADR-format ADRs covering hand-rolled libsignal-

--- a/src/main.rs
+++ b/src/main.rs
@@ -3,11 +3,13 @@
 
 mod api;
 use api::*;
-use chat::{Chat, Event};
+use chat::{AuthorFlag, Chat, Event};
+use enumset::EnumSet;
 use gam::{MenuItem, MenuPayload};
 use locales::t;
 use num_traits::*;
 use xous_signal_client::SigChat;
+use xous_signal_client::manager::outgoing;
 use xous_ipc::Buffer;
 
 fn main() -> ! {
@@ -74,6 +76,16 @@ fn wrapped_main() -> ! {
     let mut first_focus = true;
     let mut user_post: Option<String> = None;
 
+    // Optional pre-seed of the V1 default outgoing recipient from the
+    // environment. Lets a hosted-mode session send the first message
+    // without first having received one. No-op if XSC_DEMO_PEER_UUID is
+    // unset, invalid, or a recipient is already persisted.
+    match outgoing::seed_demo_recipient_from_env() {
+        Ok(true) => log::info!("seeded demo recipient from XSC_DEMO_PEER_UUID"),
+        Ok(false) => {}
+        Err(e) => log::warn!("seed_demo_recipient_from_env failed: {e}"),
+    }
+
     // Auto-connect if the account is already registered (e.g. headless scan).
     // This fires the same logic as the first Event::Focus would have.
     if sigchat.is_ready() {
@@ -82,6 +94,9 @@ fn wrapped_main() -> ! {
             Ok(true) => {
                 log::info!("connected to Signal Account");
                 sigchat.dialogue_set(Some("default"));
+                if let Err(e) = chat.set_author_flags("me", EnumSet::from(AuthorFlag::Right)) {
+                    log::warn!("set_author_flags(\"me\") failed: {e:?}");
+                }
                 match sigchat.start_receive(chat.cid()) {
                     Ok(true) => log::info!("receive worker started"),
                     Ok(false) => log::warn!("start_receive returned false"),
@@ -109,6 +124,9 @@ fn wrapped_main() -> ! {
                                         first_focus = false;
                                         log::info!("connected to Signal Account");
                                         sigchat.dialogue_set(Some("default"));
+                                        if let Err(e) = chat.set_author_flags("me", EnumSet::from(AuthorFlag::Right)) {
+                                            log::warn!("set_author_flags(\"me\") failed: {e:?}");
+                                        }
                                         match sigchat.start_receive(chat.cid()) {
                                             Ok(true) => log::info!("receive worker started"),
                                             Ok(false) => log::warn!("start_receive returned false"),

--- a/src/manager/outgoing.rs
+++ b/src/manager/outgoing.rs
@@ -110,7 +110,7 @@ pub(crate) struct EncryptedMessage {
 }
 
 #[derive(Debug)]
-pub(crate) enum OutgoingError {
+pub enum OutgoingError {
     Pddb(String),
     NoRecipient,
     NoLocalAccount(String),
@@ -389,7 +389,7 @@ fn local_protocol_address() -> Result<ProtocolAddress, OutgoingError> {
 /// Persist the most recent sender's UUID + device_id as the default outgoing
 /// recipient. Called by the receive path after a successful DataMessage
 /// delivery so that the user's reply has somewhere to go.
-pub(crate) fn set_current_recipient(remote_addr: &ProtocolAddress) -> Result<(), OutgoingError> {
+pub fn set_current_recipient(remote_addr: &ProtocolAddress) -> Result<(), OutgoingError> {
     let pddb = pddb::Pddb::new();
     pddb.try_mount();
     let payload = format!(
@@ -408,12 +408,87 @@ pub(crate) fn set_current_recipient(remote_addr: &ProtocolAddress) -> Result<(),
 
 /// Read the most recent sender as a ProtocolAddress, or `NoRecipient` if no
 /// one has messaged us yet.
-pub(crate) fn current_recipient() -> Result<ProtocolAddress, OutgoingError> {
+pub fn current_recipient() -> Result<ProtocolAddress, OutgoingError> {
     let pddb = pddb::Pddb::new();
     pddb.try_mount();
     let raw = pddb_get_string(&pddb, DIALOGUE_DICT, DEFAULT_PEER_KEY)
         .ok_or(OutgoingError::NoRecipient)?;
     parse_peer_json(&raw)
+}
+
+/// Pre-seed the default outgoing recipient from environment variables.
+///
+/// Reads `XSC_DEMO_PEER_UUID` (required, hyphenated UUID string) and
+/// `XSC_DEMO_PEER_DEVICE_ID` (optional, default 1). If both parse and a
+/// recipient is not already persisted in PDDB, calls
+/// [`set_current_recipient`] with the parsed address so a subsequent
+/// `SigChat::post()` has somewhere to send before any inbound DataMessage
+/// has populated the field via the V1 most-recent-sender mechanism.
+///
+/// Behavior:
+/// - `XSC_DEMO_PEER_UUID` unset → no-op, falls back to the V1 mechanism.
+/// - Invalid UUID format → log warning, no-op.
+/// - `XSC_DEMO_PEER_DEVICE_ID` unset → defaults to `1` (typical primary).
+/// - `XSC_DEMO_PEER_DEVICE_ID` invalid (non-numeric, 0, or >127) →
+///   log warning, no-op.
+/// - A recipient already persisted in PDDB → the seed is skipped to
+///   preserve any V1-captured peer; warn so the operator notices.
+///
+/// Returns `Ok(true)` if the seed was applied, `Ok(false)` if it was a
+/// no-op for any non-error reason (env unset, recipient already present).
+pub fn seed_demo_recipient_from_env() -> Result<bool, OutgoingError> {
+    let uuid_env = match std::env::var("XSC_DEMO_PEER_UUID") {
+        Ok(s) if !s.is_empty() => s,
+        _ => return Ok(false),
+    };
+    let dev_env = std::env::var("XSC_DEMO_PEER_DEVICE_ID").ok();
+
+    let addr = match parse_demo_peer(&uuid_env, dev_env.as_deref()) {
+        Ok(addr) => addr,
+        Err(reason) => {
+            log::warn!("XSC_DEMO_PEER_UUID/_DEVICE_ID rejected: {reason} — skipping seed");
+            return Ok(false);
+        }
+    };
+
+    if current_recipient().is_ok() {
+        log::warn!("XSC_DEMO_PEER_UUID set but a recipient is already persisted; skipping seed to preserve V1 state");
+        return Ok(false);
+    }
+
+    set_current_recipient(&addr)?;
+    log::info!(
+        "seeded demo recipient: uuid={} device_id={}",
+        addr.name(),
+        u32::from(addr.device_id()),
+    );
+    Ok(true)
+}
+
+/// Pure-function helper: validate a UUID + device_id and produce a
+/// `ProtocolAddress`. `device_id_str` of `None` defaults to 1. Returns
+/// a human-readable reason on rejection so callers can log it.
+///
+/// Hyphenated UUID format is required (36 chars, hyphens at positions
+/// 8/13/18/23, ASCII hex elsewhere). DeviceId must be 1..=127.
+fn parse_demo_peer(uuid: &str, device_id_str: Option<&str>) -> Result<ProtocolAddress, String> {
+    if uuid.len() != 36
+        || !uuid.chars().enumerate().all(|(i, c)| match i {
+            8 | 13 | 18 | 23 => c == '-',
+            _ => c.is_ascii_hexdigit(),
+        })
+    {
+        return Err(format!("not a valid hyphenated UUID: {uuid:?}"));
+    }
+    let device_id: u32 = match device_id_str {
+        Some(s) => s.parse().map_err(|e| format!("device_id parse: {e}"))?,
+        None => 1,
+    };
+    if device_id == 0 || device_id > 127 {
+        return Err(format!("device_id out of range (1..=127): {device_id}"));
+    }
+    let dev = DeviceId::new(device_id as u8).map_err(|e| format!("DeviceId: {e:?}"))?;
+    Ok(ProtocolAddress::new(uuid.to_string(), dev))
 }
 
 fn parse_peer_json(s: &str) -> Result<ProtocolAddress, OutgoingError> {
@@ -779,5 +854,63 @@ mod tests {
             &mut alice_store.session_store, &mut alice_store.identity_store,
         );
         assert!(matches!(result, Err(OutgoingError::NoSession)));
+    }
+
+    // ---- parse_demo_peer ----------------------------------------------------
+
+    const VALID_UUID: &str = "00000000-0000-4000-8000-000000000001";
+
+    #[test]
+    fn parse_demo_peer_default_device_is_1() {
+        let addr = parse_demo_peer(VALID_UUID, None).unwrap();
+        assert_eq!(addr.name(), VALID_UUID);
+        assert_eq!(u32::from(addr.device_id()), 1);
+    }
+
+    #[test]
+    fn parse_demo_peer_explicit_device() {
+        let addr = parse_demo_peer(VALID_UUID, Some("2")).unwrap();
+        assert_eq!(u32::from(addr.device_id()), 2);
+    }
+
+    #[test]
+    fn parse_demo_peer_rejects_short_uuid() {
+        let err = parse_demo_peer("00000000", None).unwrap_err();
+        assert!(err.contains("UUID"), "expected UUID error, got: {err}");
+    }
+
+    #[test]
+    fn parse_demo_peer_rejects_misplaced_hyphens() {
+        // Right length (36) but hyphens in wrong positions.
+        let bad = "000000000-0000-4000-8000-000000000001";
+        assert_eq!(bad.len(), 37, "test fixture wrong length");
+        let bad = &bad[..36];
+        let err = parse_demo_peer(bad, None).unwrap_err();
+        assert!(err.contains("UUID"));
+    }
+
+    #[test]
+    fn parse_demo_peer_rejects_non_hex() {
+        let bad = "zz000000-0000-4000-8000-000000000001";
+        let err = parse_demo_peer(bad, None).unwrap_err();
+        assert!(err.contains("UUID"));
+    }
+
+    #[test]
+    fn parse_demo_peer_rejects_device_id_zero() {
+        let err = parse_demo_peer(VALID_UUID, Some("0")).unwrap_err();
+        assert!(err.contains("out of range"), "got: {err}");
+    }
+
+    #[test]
+    fn parse_demo_peer_rejects_device_id_too_large() {
+        let err = parse_demo_peer(VALID_UUID, Some("128")).unwrap_err();
+        assert!(err.contains("out of range"), "got: {err}");
+    }
+
+    #[test]
+    fn parse_demo_peer_rejects_non_numeric_device_id() {
+        let err = parse_demo_peer(VALID_UUID, Some("abc")).unwrap_err();
+        assert!(err.contains("parse"), "got: {err}");
     }
 }

--- a/tools/demo-prep.sh
+++ b/tools/demo-prep.sh
@@ -1,0 +1,163 @@
+#!/usr/bin/env bash
+# tools/demo-prep.sh
+#
+# Recording-day setup for the hosted-mode demo. Mitigates the
+# B2-sibling priming flake (`InvalidMessage(Whisper, "decryption
+# failed")`) documented in `bug-arcs/b005-signal-cli-libsignal-decrypt.md`
+# section 2026-04-28: when the emulator's PDDB is restored to a
+# snapshot but signal-cli's `session` table still holds a session for
+# the emulator UUID, signal-cli sends Whisper SignalMessage instead of
+# PreKeyMessage and the rolled-back emulator cannot decrypt.
+#
+# What it does, in order:
+#  1. Loads tools/.env so XSC_RECIPIENT_NUMBER / XSC_SENDER_NUMBER /
+#     XSC_DEMO_PEER_UUID are visible.
+#  2. Restores the emulator's PDDB snapshot to a known-good linked state.
+#  3. Locates signal-cli's account.db for the sender account (the one
+#     signal-cli is linked to as a secondary device).
+#  4. Deletes any rows in `session` whose address column matches the
+#     emulator's account UUID (XSC_EMULATOR_UUID), forcing signal-cli's
+#     next outbound to issue a PreKey-bundle envelope.
+#  5. Runs scan-receive.sh once to re-establish a clean session and
+#     warm-up the emulator's WS auth + receive worker.
+#
+# After this script exits 0, hosted mode can be launched with
+# XSC_DEMO_PEER_UUID set and the recording can begin.
+#
+# Usage:
+#   source tools/.env  # if not already sourced
+#   ./tools/demo-prep.sh
+#
+# Exit codes:
+#   0 = ready for recording
+#   1 = setup failure (missing env, missing files, scan-receive
+#       failed); actionable error printed to stderr
+#   2 = invariant violation (e.g. account.db not where expected) —
+#       indicates the demo prep needs a maintainer pass
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+
+# 1. Load tools/.env if present and unsourced.
+if [[ -f "$ROOT/tools/.env" && -z "${XSC_RECIPIENT_NUMBER:-}" ]]; then
+    # shellcheck source=.env
+    source "$ROOT/tools/.env"
+fi
+
+if [[ -z "${XSC_RECIPIENT_NUMBER:-}" ]]; then
+    echo "ERROR: XSC_RECIPIENT_NUMBER not set; load tools/.env first" >&2
+    echo "  Example: source tools/.env" >&2
+    exit 1
+fi
+
+if [[ -z "${XSC_DEMO_PEER_UUID:-}" ]]; then
+    echo "WARN: XSC_DEMO_PEER_UUID not set; the demo will rely on the" >&2
+    echo "      V1 most-recent-sender mechanism instead of pre-seeding." >&2
+fi
+
+if [[ -z "${XSC_SENDER_NUMBER:-}" ]]; then
+    echo "ERROR: XSC_SENDER_NUMBER not set; cannot identify emulator account" >&2
+    exit 1
+fi
+
+# 2. Restore PDDB snapshot.
+XOUS_CORE_PATH="${XOUS_CORE_PATH:-$ROOT/../xous-core}"
+PDDB_SNAPSHOT="${XSC_PDDB_IMAGE:-$XOUS_CORE_PATH/tools/pddb-images/hosted-linked-display-verified.bin}"
+HOSTED_BIN="$XOUS_CORE_PATH/tools/pddb-images/hosted.bin"
+
+if [[ ! -f "$PDDB_SNAPSHOT" ]]; then
+    echo "ERROR: PDDB snapshot not found: $PDDB_SNAPSHOT" >&2
+    exit 1
+fi
+
+echo "Restoring PDDB snapshot..."
+cp "$PDDB_SNAPSHOT" "$HOSTED_BIN"
+
+# 3. Locate signal-cli's account.db for the sender account.
+SIGNAL_CLI_ROOT="${SIGNAL_CLI_ROOT:-$HOME/.local/share/signal-cli}"
+# signal-cli stores accounts under data/<account_id>.d/account.db.
+# accounts.json maps phone numbers to account IDs; we walk it to find
+# the right one rather than guessing.
+ACCOUNTS_JSON="$SIGNAL_CLI_ROOT/data/accounts.json"
+if [[ ! -f "$ACCOUNTS_JSON" ]]; then
+    echo "ERROR: signal-cli accounts.json not found: $ACCOUNTS_JSON" >&2
+    exit 2
+fi
+
+SIGNAL_DB="$(python3 -c "
+import json, os, sys
+target = sys.argv[1]
+with open(sys.argv[2]) as f:
+    data = json.load(f)
+for acc in data.get('accounts', []):
+    if acc.get('number') == target:
+        path = acc.get('path')
+        if path and not os.path.isabs(path):
+            path = os.path.join(os.path.dirname(sys.argv[2]), path)
+        # signal-cli convention: \"<path>\" is a file marker, the DB
+        # lives in \"<path>.d/account.db\".
+        db_dir = path + '.d' if not path.endswith('.d') else path
+        print(os.path.join(db_dir, 'account.db'))
+        sys.exit(0)
+sys.exit(3)
+" "$XSC_RECIPIENT_NUMBER" "$ACCOUNTS_JSON" 2>/dev/null || true)"
+
+if [[ -z "$SIGNAL_DB" || ! -f "$SIGNAL_DB" ]]; then
+    echo "ERROR: signal-cli account.db not found for $XSC_RECIPIENT_NUMBER" >&2
+    echo "       walked $ACCOUNTS_JSON; got: '${SIGNAL_DB:-<empty>}'" >&2
+    exit 2
+fi
+
+# 4. Delete sessions for the emulator UUID. This is the documented
+# B2-sibling workaround. See bug-arcs/b005 section 2026-04-28.
+# Look up the UUID via signal-cli's recipient table (JOIN by phone
+# number) so the script works with just XSC_SENDER_NUMBER set.
+echo "Clearing signal-cli sessions for emulator account ($XSC_SENDER_NUMBER)..."
+read -r EMULATOR_UUID DELETED < <(python3 -c "
+import sqlite3, sys
+db, number = sys.argv[1], sys.argv[2]
+con = sqlite3.connect(db)
+row = con.execute('SELECT aci FROM recipient WHERE number = ?', (number,)).fetchone()
+if not row or not row[0]:
+    print('NONE 0')
+    sys.exit(0)
+uuid = row[0]
+cur = con.execute('DELETE FROM session WHERE address = ?', (uuid,))
+con.commit()
+print(uuid, cur.rowcount)
+con.close()
+" "$SIGNAL_DB" "$XSC_SENDER_NUMBER")
+
+if [[ "$EMULATOR_UUID" == "NONE" ]]; then
+    echo "  WARN: no recipient row for $XSC_SENDER_NUMBER in signal-cli" >&2
+    echo "        recipient table; nothing to clear. signal-cli may not" >&2
+    echo "        have ever messaged this number, in which case there is" >&2
+    echo "        no stale session to worry about. Continuing." >&2
+else
+    echo "  uuid=$EMULATOR_UUID; deleted $DELETED row(s) from session table"
+fi
+
+# 5. Warm up: run scan-receive.sh once to re-establish a clean session.
+# scan-receive.sh handles its own boot/teardown of the emulator.
+echo ""
+echo "=== Warming up via scan-receive.sh ==="
+if "$SCRIPT_DIR/scan-receive.sh"; then
+    echo ""
+    echo "Demo prep complete. Hosted mode is ready for recording."
+    echo "To record:"
+    if [[ -n "${EMULATOR_UUID:-}" && "$EMULATOR_UUID" != "NONE" ]]; then
+        echo "  export XSC_DEMO_PEER_UUID=\"$EMULATOR_UUID\"   # or whatever your peer is"
+    else
+        echo "  export XSC_DEMO_PEER_UUID=<uuid>   # set the demo peer's UUID here"
+    fi
+    echo "  cd $XOUS_CORE_PATH && cargo xtask run sigchat:$ROOT/target/release/xous-signal-client"
+    exit 0
+else
+    rc=$?
+    echo "" >&2
+    echo "ERROR: scan-receive.sh failed (exit $rc); demo prep incomplete." >&2
+    echo "       See scan-receive log for diagnostic details." >&2
+    exit 1
+fi

--- a/tools/test-env.example
+++ b/tools/test-env.example
@@ -37,3 +37,12 @@ export XSC_RECIPIENT_UUID="00000000-0000-0000-0000-000000000000"
 # X11 display where the Xous emulator window appears during hosted-mode
 # scans. Defaults to :10 to match the existing scan harness.
 # export DISPLAY=":10"
+
+# Demo recording: pre-seed the V1 default outgoing recipient so the
+# emulator can send the first message of a recording without first
+# having received one. UUID format only; will be skipped (with a log
+# warning) if invalid. Optional XSC_DEMO_PEER_DEVICE_ID, default 1
+# (range 1..=127). Production paths populate the recipient from
+# inbound DataMessages and ignore these vars.
+# export XSC_DEMO_PEER_UUID="00000000-0000-0000-0000-000000000000"
+# export XSC_DEMO_PEER_DEVICE_ID="1"


### PR DESCRIPTION
## Summary

Two small additions that complete the demo plan from
\`xous-signal-client-notes/_open-followups/demo-plan.md\`. After this
PR lands, hosted mode is recording-ready:

- **Right-aligned local-author bubbles.** \`main.rs\` calls
  \`chat::Chat::set_author_flags("me", AuthorFlag::Right)\` after
  \`dialogue_set\`; chat-lib's bubble layout already honored the flag.
  Depends on the new \`Chat::set_author_flags\` API added to chat-lib
  on the project's pinned \`feat/05-curve25519-dalek-4.1.3\` branch
  (PR tracked at tunnell/xous-core#17;
  see \`xous-signal-client-notes/techContext.md\` patch table).
- **\`XSC_DEMO_PEER_UUID\` env-var seam** (+ optional
  \`XSC_DEMO_PEER_DEVICE_ID\`, default 1). Pre-seeds the V1 default
  outgoing recipient at startup so a hosted-mode session can send
  before first receiving. Validates UUID format and device-id range;
  falls back to current behavior on unset/invalid input or when a
  recipient is already persisted.
- **\`tools/demo-prep.sh\`**: recording-day setup. Looks up the
  emulator's UUID via signal-cli's \`recipient\` table by phone number,
  deletes any stale \`session\` rows for that UUID (B2-sibling
  priming-flake mitigation per \`bug-arcs/b005\`), restores the PDDB
  snapshot, and runs \`scan-receive.sh\` once to warm up.

## Test plan

- [x] \`cargo test --features hosted --lib\`: 104 passed (8 new
      \`parse_demo_peer_*\` cases). Was 96 before this PR.
- [x] \`./tools/scan-send.sh\`: PASS (leg-1 + leg-2).
- [x] \`./tools/scan-receive.sh\`: PASS via demo-prep.sh.
- [x] \`./tools/demo-prep.sh\`: end-to-end clean run; scan-receive PASS;
      stale signal-cli sessions cleared deterministically.
- [x] Hosted boot smoke with \`XSC_DEMO_PEER_UUID\` set: log shows
      \`seeded demo recipient from XSC_DEMO_PEER_UUID\` and
      \`ChatOp::SetAuthorFlags\` reaches the chat server.
- [ ] Visual confirmation of right-aligned "me" bubble (deferred to
      recording session — needs in-emulator typing).

## Docs updated (per maintenance contract)

- \`AGENTS.md\` — \`demo-prep.sh\` under Testing, new env vars under
  Diagnostic instrumentation, new "Repository scope for git operations"
  section codifying tunnell-only push/PR scope.
- \`CHANGELOG.md\` — \`[Unreleased]\` / Added entries.
- \`tools/test-env.example\` — new env vars documented.
- \`xous-signal-client-notes/techContext.md\` (separate notes repo) —
  xous-core patch table updated.

Generated with an AI agent.