### PR TITLE
docs: flag headless-Xvfb DISPLAY gotcha for hosted-mode runs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -85,6 +85,15 @@ cargo xtask run sigchat:../xous-signal-client/target/release/xous-signal-client
 # in xous-core's app-allowlist under that name (see "What this is").
 ```
 
+The emulator window appears on whichever X display is active when
+`cargo xtask run` is invoked. **`DISPLAY=:10` is often a Xvfb (virtual
+framebuffer) — the emulator runs but no window is viewable.** To check:
+`ls /tmp/.X11-unix/` shows running X servers (`X10` = `:10`); `pgrep
+-af Xvfb` confirms whether `:10` is headless. On hosts where `:10` is
+Xvfb, set `DISPLAY` to a viewable display (e.g. `localhost:11.0` for a
+TCP-forwarded X11 socket on port 6011) before launching. See also
+`tools/test-env.example` for a commented hint.
+
 ## Testing
 
 Three test families exist; see `tests/README.md` for full

--- a/tools/test-env.example
+++ b/tools/test-env.example
@@ -36,6 +36,15 @@ export XSC_RECIPIENT_UUID="00000000-0000-0000-0000-000000000000"
 
 # X11 display where the Xous emulator window appears during hosted-mode
 # scans. Defaults to :10 to match the existing scan harness.
+#
+# Gotcha: on many development hosts `:10` is a Xvfb (virtual framebuffer
+# = headless). If you see no window when launching the emulator, the
+# display is headless. Diagnose:
+#     ls /tmp/.X11-unix/        # which X servers exist
+#     pgrep -af Xvfb            # is :10 a Xvfb?
+# If `:10` is headless, set DISPLAY to a viewable display. On hosts that
+# expose a TCP-forwarded X11 socket on port 6011, use:
+#     export DISPLAY="localhost:11.0"
 # export DISPLAY=":10"
 
 # Demo recording: pre-seed the V1 default outgoing recipient so the


### PR DESCRIPTION
## Summary

Adds a paragraph to AGENTS.md "Run hosted" and a commented hint to `tools/test-env.example` explaining the failure mode where `DISPLAY=:10` is a Xvfb (virtual framebuffer): the emulator boots, the WS authenticates, messages decrypt — and no window is viewable.

The 2026-04-28 demo recording session lost ~10 minutes diagnosing this the first time. The fix on hosts with a TCP-forwarded X11 socket on port 6011 is `DISPLAY=localhost:11.0`. Diagnostic commands (`ls /tmp/.X11-unix/`, `pgrep -af Xvfb`) are inline so the next person can identify their setup quickly.

Closes #12.

## Test plan

- [x] Doc-only — no code paths changed.
- [x] `cargo test --features hosted` — 104 passed, 0 failed (same as pre-change).
- [ ] Reviewer confirms the inline diagnostic commands match common Linux setups (e.g. `/tmp/.X11-unix/X10` notation, `pgrep -af Xvfb` output format).