### PR TITLE
fix(account_attrs): drop legacy signalingKey, voice, video fields

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Changed
 
+- `AccountAttributes` JSON payload (sent on link / registration; pre-required
+  for the upcoming `PUT /v1/accounts/attributes` in #16) now omits three
+  legacy fields: `signalingKey` (obsolete since libsignal Double Ratchet
+  ~2017), `voice`, and `video` (modern Signal-Server carries voice/video
+  capability under the `capabilities` sub-object, not at the top level).
+  The remaining 10 top-level fields and the 5 capability sub-fields match
+  modern Signal-Server's `AccountAttributes` entity. Three new unit tests
+  pin the absence of the legacy fields and the exact set of top-level
+  keys. Closes #17.
 - WebSocket upgrade handshake now sends `X-Signal-Receive-Stories: false`
   (was `true`). xous-signal-client has no Story-rendering UI; asking the
   server for Story envelopes wasted bandwidth and decryption cycles on

--- a/src/manager/account_attrs.rs
+++ b/src/manager/account_attrs.rs
@@ -85,14 +85,25 @@ pub struct Capabilities {
     pub spqr: bool,
 }
 
+/// JSON shape of the `accountAttributes` field on the link / registration
+/// REST body, and (per issue #16) on the post-link
+/// `PUT /v1/accounts/attributes` call.
+///
+/// Field set matches modern Signal-Server's `AccountAttributes` entity.
+/// Three legacy fields removed in issue #17:
+/// - `signalingKey` (pre-libsignal Double Ratchet HMAC key; obsolete since
+///   the libsignal protocol replaced the old AxolotlRatchet ~2017).
+/// - `voice` / `video` (legacy top-level booleans; modern Signal-Server
+///   carries voice/video capability via the `capabilities` sub-object,
+///   not at the top level).
+///
+/// Server-side parsers tolerate the legacy fields when present (Jackson
+/// `@JsonIgnoreProperties(ignoreUnknown = true)`), but sending them was
+/// dead weight on every link/attributes call.
 #[derive(Serialize)]
 pub struct AccountAttributes {
-    #[serde(rename = "signalingKey")]
-    pub signaling_key: Option<String>,
     #[serde(rename = "registrationId")]
     pub registration_id: u32,
-    pub voice: bool,
-    pub video: bool,
     #[serde(rename = "fetchesMessages")]
     pub fetches_messages: bool,
     #[serde(rename = "registrationLock")]
@@ -119,10 +130,7 @@ pub fn build_account_attributes(
 ) -> Result<AccountAttributes, Error> {
     let uak = derive_unidentified_access_key(profile_key)?;
     Ok(AccountAttributes {
-        signaling_key: None,
         registration_id: registration_id as u32,
-        voice: true,
-        video: true,
         fetches_messages: true,
         registration_lock: None,
         unidentified_access_key: STANDARD.encode(uak),
@@ -199,10 +207,7 @@ mod tests {
         let json = serde_json::to_value(&attrs).expect("serialize");
         // Spot-check the renamed/camelCase fields that Signal's server parses.
         for key in [
-            "signalingKey",
             "registrationId",
-            "voice",
-            "video",
             "fetchesMessages",
             "registrationLock",
             "unidentifiedAccessKey",
@@ -219,10 +224,85 @@ mod tests {
         for key in ["storage", "versionedExpirationTimer", "attachmentBackfill", "ssre2", "spqr"] {
             assert_eq!(caps.get(key), Some(&serde_json::Value::Bool(true)), "capabilities.{} should be true", key);
         }
-        assert_eq!(json["signalingKey"], serde_json::Value::Null);
         assert_eq!(json["registrationLock"], serde_json::Value::Null);
         assert_eq!(json["recoveryPassword"], serde_json::Value::Null);
         assert_eq!(json["registrationId"], serde_json::json!(42));
         assert_eq!(json["pniRegistrationId"], serde_json::json!(43));
+    }
+
+    #[test]
+    fn attributes_omit_legacy_signaling_key() {
+        // signalingKey is the pre-libsignal Double Ratchet HMAC key; obsolete
+        // since ~2017 when libsignal replaced the old AxolotlRatchet protocol.
+        // Modern Signal-Server's AccountAttributes entity ignores it. Issue #17
+        // dropped this field entirely from our payload.
+        let attrs = build_account_attributes(
+            "ZGV2aWNlLW5hbWU=".to_string(),
+            &[0u8; 32],
+            42,
+            43,
+        )
+        .expect("build");
+        let json = serde_json::to_value(&attrs).expect("serialize");
+        assert!(
+            json.get("signalingKey").is_none(),
+            "signalingKey is legacy and must not appear in modern AccountAttributes"
+        );
+    }
+
+    #[test]
+    fn attributes_omit_legacy_voice_video_top_level() {
+        // Modern Signal-Server carries voice/video signaling capability under
+        // the `capabilities` sub-object, not as top-level booleans. Issue #17
+        // dropped both `voice` and `video` from the top level. capabilities
+        // sub-object remains and is asserted by the round-trip test above.
+        let attrs = build_account_attributes(
+            "ZGV2aWNlLW5hbWU=".to_string(),
+            &[0u8; 32],
+            42,
+            43,
+        )
+        .expect("build");
+        let json = serde_json::to_value(&attrs).expect("serialize");
+        assert!(
+            json.get("voice").is_none(),
+            "voice is a legacy top-level field; modern signal moves it under capabilities"
+        );
+        assert!(
+            json.get("video").is_none(),
+            "video is a legacy top-level field; modern signal moves it under capabilities"
+        );
+    }
+
+    #[test]
+    fn attributes_payload_contains_only_modern_fields() {
+        // Pin the exact set of top-level keys we send. A future regression
+        // that re-introduces a deprecated field (or accidentally drops a
+        // required one) will surface here.
+        let attrs = build_account_attributes(
+            "ZGV2aWNlLW5hbWU=".to_string(),
+            &[0u8; 32],
+            42,
+            43,
+        )
+        .expect("build");
+        let json = serde_json::to_value(&attrs).expect("serialize");
+        let obj = json.as_object().expect("AccountAttributes serializes to a JSON object");
+        let mut got: Vec<&str> = obj.keys().map(String::as_str).collect();
+        got.sort();
+        let mut want: Vec<&str> = vec![
+            "capabilities",
+            "discoverableByPhoneNumber",
+            "fetchesMessages",
+            "name",
+            "pniRegistrationId",
+            "recoveryPassword",
+            "registrationId",
+            "registrationLock",
+            "unidentifiedAccessKey",
+            "unrestrictedUnidentifiedAccess",
+        ];
+        want.sort();
+        assert_eq!(got, want, "AccountAttributes top-level field set drifted");
     }
 }


### PR DESCRIPTION
## Summary

Drops three legacy fields from the `AccountAttributes` JSON payload (sent on link / registration; pre-required for the upcoming `PUT /v1/accounts/attributes` in #16):

- **`signalingKey`** — pre-libsignal Double Ratchet HMAC key. Obsolete since libsignal replaced AxolotlRatchet ~2017. The previous code always sent `null` for this; modern Signal-Server's `AccountAttributes` entity has no field.
- **`voice` / `video`** — top-level booleans predating Signal's move of voice/video signaling into the `capabilities` sub-object. Modern Signal-Server treats these as ignored at the top level.

Server-side parsers tolerate the legacy fields (Jackson `@JsonIgnoreProperties(ignoreUnknown=true)`), but sending them was dead weight on every link/attributes call.

## What stays

The 10 remaining top-level fields and the 5 capability sub-fields match modern Signal-Server's `AccountAttributes` entity:

| Top-level | Capabilities sub-object |
|---|---|
| `registrationId` | `storage` |
| `fetchesMessages` | `versionedExpirationTimer` |
| `registrationLock` | `attachmentBackfill` |
| `unidentifiedAccessKey` | `ssre2` |
| `unrestrictedUnidentifiedAccess` | `spqr` |
| `discoverableByPhoneNumber` | |
| `capabilities` | |
| `name` | |
| `pniRegistrationId` | |
| `recoveryPassword` | |

## Tests added (3)

| Test | Purpose |
|---|---|
| `attributes_omit_legacy_signaling_key` | Pins absence of `signalingKey` in the JSON |
| `attributes_omit_legacy_voice_video_top_level` | Pins absence of `voice` and `video` at the top level (capabilities sub-object remains) |
| `attributes_payload_contains_only_modern_fields` | Pins the exact set of top-level keys — a future regression that re-introduces a deprecated field, or accidentally drops a required one, fails this test |

`attributes_serialize_with_expected_field_names` (existing) was updated to no longer assert the removed fields are present.

## Out of scope

Issue #17 acceptance criterion #3 ("Separate link-time fields from per-device fields cleanly") isn't actioned in this PR. The struct currently has one consumer (link). It gets a second consumer on #16 (post-link `PUT /v1/accounts/attributes`). The separation only matters once both consumers exist and need different field sets — revisit during #16.

## Test plan

- [x] `cargo test --features hosted` → **111 passed, 0 failed, 13 ignored** (was 108 passed; +3 new).
- [x] `cargo build --features hosted` → clean (no dangling references to removed fields anywhere in `src/`).
- [x] Reviewed all `.signaling_key` / `.voice` / `.video` matches via grep — only matches are in the new doc comment + the absence-tests in `account_attrs.rs`.
- [ ] Reviewer confirms a fresh device-link still succeeds with the new payload (the live server tolerates both old and new shapes; this is just a defensive check).

## Acceptance-criteria mapping

- [x] Audit current capabilities payload against libsignal-service-rs reference → done; the 5 capability sub-fields match.
- [x] Drop deprecated fields → `signalingKey`, `voice`, `video` removed.
- [ ] Separate link-time fields from per-device fields cleanly → **deferred to #16**, see "Out of scope" above.
- [x] Unit test for the serialization → 3 new tests + 1 updated.

Closes #17.