### PR TITLE
fix: close B2 — signal-cli libsignal decrypt failure no longer reproducible

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Changed
 
+- B2 (issue #8) closed: signal-cli libsignal `InvalidMessageException`
+  on the emulator's post-409-retry CIPHERTEXT is no longer reproducible
+  after the receive-direction priming-flake fix in PR #30 (issue #9).
+  Three consecutive `scan-send.sh` runs all PASSed leg-1 + leg-2.
+  Removed the `KNOWN_FAIL` exit-87 mapping from `tools/scan-send.sh`
+  and `tools/run-all-tests.sh`; moved B2 to `tests/known-issues.md`'s
+  "Resolved" section. `scan-send.sh` retains a defensive recognizer
+  that emits a "B2 regression?" diagnostic if the pattern ever
+  re-occurs (exits 1, not 87).
 - `tools/measure-renode.sh`: previously exited 2 (skip) when Renode
   refused to compile `LiteX_Timer_32.cs` due to a `long`/`ulong`
   mismatch against Renode 1.16.1. The cast itself is now fixed in

--- a/tests/README.md
+++ b/tests/README.md
@@ -37,21 +37,23 @@ Skip flags are available for selective runs:
 
 ### KNOWN_FAIL results
 
-Some test families may report **KNOWN_FAIL** instead of PASS or FAIL. A
-KNOWN_FAIL is a failure whose root cause is understood and documented in
-[`known-issues.md`](known-issues.md). The orchestrator exits 0 when all
-non-KNOWN_FAIL results pass — KNOWN_FAIL is surfaced honestly in the
-summary without blocking the suite.
+A `KNOWN_FAIL` is a failure whose root cause is understood and
+documented in [`known-issues.md`](known-issues.md). The orchestrator
+exits 0 when all non-`KNOWN_FAIL` results pass — `KNOWN_FAIL` is
+surfaced honestly in the summary without blocking the suite.
 
 The conventions:
 
-- `scan-send.sh` exits with code **87** when it detects the B2 pattern
-  (`InvalidMessageException: decryption failed` from signal-cli after a
-  409-retry send). The orchestrator maps exit 87 → `KNOWN_FAIL`.
+- A scan script exits with code **87** when it detects a documented
+  known-issue pattern. The orchestrator maps exit 87 → `KNOWN_FAIL`.
 - Any other non-zero exit from a scan script is still `FAIL` (exit 1)
   or `SKIPPED` (exit 2).
 - When a known issue is resolved, delete its entry from `known-issues.md`
   and remove the KNOWN_FAIL handling from the relevant scan script.
+
+There are no current `KNOWN_FAIL` patterns wired today (B2 was the
+last one, resolved 2026-04-28; see `known-issues.md` "Resolved"
+section). The infrastructure is preserved for future use.
 
 ### From a fresh clone
 
@@ -352,18 +354,16 @@ The script exits 0 only when both legs pass.
 | Code | Meaning |
 |------|---------|
 | 0 | leg-1 PASS + leg-2 PASS |
-| 1 | leg-1 FAIL, or leg-2 FAIL with unexpected output |
+| 1 | leg-1 FAIL, or leg-2 FAIL (any reason) |
 | 2 | Setup failure (missing env, prerequisite, topology) |
-| 87 | leg-1 PASS + leg-2 KNOWN_FAIL (see `tests/known-issues.md`) |
+| 87 | Reserved for documented `KNOWN_FAIL` patterns (currently unused — see `known-issues.md`) |
 
-**Current known state of leg-2.**
-As of 2026-04-27, signal-cli's libsignal returns
-`InvalidMessageException: invalid Whisper message: decryption failed`
-on the emulator's post-409-retry CIPHERTEXT (B2 in
-`known-issues.md`). The script exits 87 and the orchestrator reports
-`KNOWN_FAIL`. iOS Signal on the recipient's primary phone received
-the same message correctly in earlier sessions — this is a
-signal-cli-specific session-state divergence, not a wire-format bug.
+**Current expected state of leg-2.** Both legs pass cleanly. B2
+(signal-cli libsignal `InvalidMessageException` on the emulator's
+post-409-retry CIPHERTEXT) was resolved 2026-04-28 — see
+`known-issues.md` "Resolved". `scan-send.sh` retains a defensive
+recognizer for the B2 pattern; if it ever re-occurs, the script
+emits a "B2 regression?" diagnostic and exits 1 (FAIL).
 
 **Verify wire bytes (leg 1):**
 

--- a/tests/known-issues.md
+++ b/tests/known-issues.md
@@ -1,111 +1,43 @@
 # Known test failures
 
-This file documents test failures whose root cause is understood but whose
-fix is deferred to a dedicated protocol-debugging session. Each entry has
-an anchor used by `tools/scan-send.sh` and `tools/run-all-tests.sh` to
-label `KNOWN_FAIL` results.
+This file documents test failures whose root cause is understood but
+whose fix is deferred. Each open entry has an anchor used by
+`tools/scan-send.sh` and `tools/run-all-tests.sh` to label results,
+plus a resolution checklist for the eventual fix.
 
 A `KNOWN_FAIL` does not block the overall test suite (the orchestrator
-exits 0). It surfaces the failure honestly in the summary output instead
-of hiding it as a PASS or SKIP.
+exits 0). It surfaces the failure honestly in the summary output
+instead of hiding it as a PASS or SKIP. There are no `KNOWN_FAIL`
+exit codes wired today — see "Resolved" below.
 
-When a known issue is fixed, remove the `KNOWN_FAIL` handling from the
-relevant scan script, delete the entry here, and update `tests/README.md`.
+When a known issue surfaces, add an entry here, wire the detection
+into the relevant scan script with exit 87, and add the mapping to
+`tools/run-all-tests.sh`.
 
 ---
 
-## B2 — signal-cli libsignal decrypt failure after 409-retry ciphertext {#b2-signal-cli-libsignal-decrypt-fail}
+## Currently open
 
-**Status:** Open as KNOWN_FAIL — but **send-direction not currently
-reproducible**. As of 2026-04-28, five consecutive scan-send runs
-(all exercising the documented `409 missing=[1] → ok on attempt 2
-(devices=[1, 2])` retry path) produced `Body:` confirmation from
-signal-cli with no decrypt failure. The PR #4 hypothesis
-(409 retry advances emulator's chain past signal-cli's) is
-contradicted by these results. The KNOWN_FAIL handling stays in
-place because the 2026-04-28 investigation surfaced the same
-libsignal failure-mode string in the *receive* direction (signal-cli
-priming inbound → emulator), triggered by PDDB-snapshot rollback
-while signal-cli's session state moves forward across runs. See
-`xous-signal-client-notes/bug-arcs/b005-signal-cli-libsignal-decrypt.md`
-2026-04-28 section for the full evidence and the sharpened next
-investigation plan.
+*(none)*
 
-**Symptom.**
-After `scan-send.sh` observes the emulator's `post: sent to ...` log line
-(leg-1 success), running `signal-cli -a $XSC_RECIPIENT_NUMBER receive`
-produces an exception rather than a `Body:` line:
+---
 
-```
-Envelope from: "Precursor2" +31653138693 (device: 2) to +31638295471
-Timestamp: <ts>
-Exception: org.signal.libsignal.protocol.InvalidMessageException:
-  invalid Whisper message: decryption failed (ProtocolInvalidMessageException)
-```
+## Resolved
 
-**Not affected.**
-- Receive in the other direction: `scan-receive.sh` (signal-cli → emulator)
-  passes cleanly.
-- iOS Signal on Precursor1's primary phone: messages from the emulator
-  appeared correctly in v6 and v7 scan sessions. signal-cli and iOS Signal
-  have independent libsignal implementations; signal-cli is stricter.
-- The sync transcript delivered to the emulator's own secondary device
-  (device 1 = the emulator itself) also passes — the emulator can read its
-  own sent message back.
+### B2 — signal-cli libsignal decrypt failure on emulator's post-409-retry CIPHERTEXT
 
-**Affected leg.**
-Leg 2 of the three-legged stool — recipient parse at the protocol layer.
-Leg 1 (wire bytes accepted by server) is confirmed PASS. Leg 3 (user-
-visible on phone) was confirmed PASS in earlier sessions against iOS Signal.
+**Resolved:** 2026-04-28 (issue #8). Closed when three consecutive
+`scan-send.sh` runs all PASSed leg-1 + leg-2 with no
+`InvalidMessageException` after the receive-direction priming-flake
+sibling was fixed in PR #30 (issue #9). The send-direction symptom
+last reproduced in 2026-04-27 (PR #4 manifestation) and has not
+surfaced since.
 
-**Hypothesized cause.**
-The emulator's send path executes a 409-retry when Signal-Server reports
-`missingDevices=[1]` on the first PUT. During the retry it establishes a
-new session with device 1, which advances the ratchet chain counter. The
-CIPHERTEXT envelope sent on retry uses a chain index that signal-cli's
-libsignal considers out of sync with its own session record (possibly
-because signal-cli's session record was last updated during the priming
-step, before the retry path advanced the counter on the emulator's side).
+**Bug arc:** `xous-signal-client-notes/bug-arcs/b005-signal-cli-libsignal-decrypt.md`
+preserves the full investigation history.
 
-The full retry path: `manager/send.rs` → 409 handling → `add_missing` →
-`process_prekey_bundle` for device 1 → session established → re-encrypt
-all devices → PUT again. The ratchet state written by `process_prekey_bundle`
-and the state that signal-cli holds may diverge if the priming-step ciphertext
-and the retry-path ciphertext are not strictly ordered in signal-cli's ratchet.
-
-**Evidence.**
-- Observed in session 2026-04-27 (Phase R+ / PR #3); confirmed by running
-  `signal-cli -a +31638295471 receive` immediately after scan-send PASS.
-- The exception message (`decryption failed`) matches libsignal's branch for
-  `InvalidMessageException` at the inner `DecryptionCallback`, not a tag or
-  padding error — so the envelope framing is valid; the failure is
-  specifically in the Double Ratchet decrypt step.
-- Scan log shows the correct 409 → retry sequence:
-  ```
-  send: 409 missing=[1] extra=[] (sent for 1 devices)
-  send: ok on attempt 2 (devices=[1, 2])
-  ```
-
-**To debug.**
-Start a fresh protocol-debugging session with these artifacts in scope:
-1. `XSCDEBUG_DUMP=1` wire capture from the failing send — run
-   `./tools/decode-wire.sh` and confirm device-2 (signal-cli) ciphertext
-   is present and well-formed.
-2. signal-cli `--verbose` receive output, which shows the full envelope
-   type (should be CIPHERTEXT = type 1, not PREKEY_BUNDLE = type 3 on
-   retry) and the ratchet state signal-cli has for that sender+device.
-3. The emulator's `XSCDEBUG_DUMP` log for the add_missing path — confirm
-   it calls `process_prekey_bundle` for device 2 (signal-cli) during the
-   retry, not just device 1.
-
-   If device 2 is NOT getting a prekey-bundle fetch and re-encrypt on retry,
-   the fix is in `manager/send.rs`'s `add_missing` logic.
-   If device 2 IS getting a fresh bundle, the divergence is in session-record
-   persistence between the priming step and the retry.
-
-**When fixed.**
-- Remove the `KNOWN_FAIL` leg-2 branch from `tools/scan-send.sh` (the
-  `InvalidMessageException` grep and exit 87 path).
-- Update `tools/run-all-tests.sh` so exit 87 from scan-send.sh is no longer
-  treated as a non-blocking result (it should no longer occur).
-- Delete this entry and update `tests/README.md` accordingly.
+**Defensive guard:** `tools/scan-send.sh`'s leg-2 branch still
+recognizes the `InvalidMessageException` pattern and surfaces a
+clear "B2 regression?" message if it re-occurs, but exits with
+status 1 (FAIL) rather than 87 (KNOWN_FAIL). If the pattern returns,
+re-open issue #8 with a reproduction.

--- a/tools/run-all-tests.sh
+++ b/tools/run-all-tests.sh
@@ -93,9 +93,6 @@ else
     if (( SEND_EXIT == 0 )); then
         RESULTS[send]="PASS"
         DETAIL[send]="leg-1 + leg-2 PASS; verify via decode-wire.sh + phones"
-    elif (( SEND_EXIT == 87 )); then
-        RESULTS[send]="KNOWN_FAIL"
-        DETAIL[send]="B2: signal-cli libsignal decrypt fail (see tests/known-issues.md)"
     elif (( SEND_EXIT == 2 )); then
         RESULTS[send]="SKIPPED"
         DETAIL[send]="setup failure in scan-send.sh"

--- a/tools/scan-send.sh
+++ b/tools/scan-send.sh
@@ -352,14 +352,22 @@ if echo "$RECV_OUT" | grep -qF "Body: $MESSAGE"; then
     echo "  Check both phones to confirm leg-3 (user-visible)."
     exit 0
 elif echo "$RECV_OUT" | grep -qiE "InvalidMessageException.*decryption failed|ProtocolInvalidMessageException"; then
+    # B2 (issue #8) — closed 2026-04-28 after the receive-direction
+    # priming-flake sibling was fixed in PR #30 (issue #9). Three
+    # consecutive scan-send PASSes confirmed B2 send-direction is no
+    # longer reachable. We keep this branch as a *regression detector*
+    # so a future re-occurrence surfaces with a clear pointer rather
+    # than a generic "no Body line" FAIL — but exit 1 (FAIL), not 87
+    # (KNOWN_FAIL). bug-arcs/b005 is the historical record.
     echo ""
-    echo "=== leg-2 KNOWN_FAIL: signal-cli libsignal decrypt failure (B2) ==="
-    echo "  See tests/known-issues.md#b2-signal-cli-libsignal-decrypt-fail"
-    echo "  leg-1 PASS; leg-2 blocked by known issue B2."
-    echo "  iOS Signal on Precursor1 phone confirmed receiving in prior sessions."
+    echo "=== leg-2 FAIL: signal-cli libsignal decrypt failure (B2 regression?) ==="
+    echo "  Pattern matches issue #8 (closed 2026-04-28). If reproducible:"
+    echo "  - Verify session state on both ends matches (pre-test session-clear)"
+    echo "  - Re-open issue #8 with reproduction steps"
+    echo "  - See bug-arcs/b005 for historical investigation notes"
     echo ""
-    echo "RESULT: KNOWN_FAIL (B2 — see tests/known-issues.md)"
-    exit 87
+    echo "RESULT: FAIL (leg-1 PASS; leg-2 FAIL — possible B2 regression)"
+    exit 1
 else
     echo ""
     echo "=== leg-2 FAIL: no Body: line and no known-exception pattern ==="


### PR DESCRIPTION
## Summary

Closes B2 (issue #8). Three consecutive `scan-send.sh` runs after the receive-direction priming-flake fix in PR #30 (issue #9) all PASSed leg-1 + leg-2 with no `InvalidMessageException`. The send-direction symptom is no longer reachable through the standard test harness.

## Why this is closeable now

B2's KNOWN_FAIL was held open *because* the same libsignal failure-mode string surfaced in the receive direction (priming-flake sibling). PR #30 fixed the priming flake by clearing signal-cli's stale sessions before the priming send. With both directions clean, B2's load-bearing reason is gone.

## Verification: three consecutive PASSes

```
=== Run 1 ===
=== leg-1 PASS: post: sent observed ===
Body: Test
=== leg-2 PASS: Body: Test confirmed by signal-cli ===
RESULT: PASS (leg-1 + leg-2)

=== Run 2 ===
=== leg-1 PASS: post: sent observed ===
Body: Test
=== leg-2 PASS: Body: Test confirmed by signal-cli ===
RESULT: PASS (leg-1 + leg-2)

=== Run 3 ===
=== leg-1 PASS: post: sent observed ===
Body: Test
=== leg-2 PASS: Body: Test confirmed by signal-cli ===
RESULT: PASS (leg-1 + leg-2)
```

## What changed

| File | Change |
|---|---|
| `tools/scan-send.sh` | Removed exit-87 KNOWN_FAIL branch. The `InvalidMessageException` recognizer remains as a **defensive guard** — if B2 ever re-occurs, the script emits a "B2 regression?" diagnostic and exits 1 (FAIL), not 87 (KNOWN_FAIL). |
| `tools/run-all-tests.sh` | Removed `SEND_EXIT == 87 → KNOWN_FAIL` mapping. No `KNOWN_FAIL` patterns wired today; infrastructure preserved. |
| `tests/known-issues.md` | Rewrote to: header explaining the convention, "Currently open: *(none)*", and a "Resolved" section with B2's closure rationale + bug-arc pointer. |
| `tests/README.md` | Updated KNOWN_FAIL section: "no current entries"; updated scan-send.sh exit-code table; updated leg-2 expected-state paragraph. |
| `CHANGELOG.md` | `[Unreleased] Changed` entry. |

## Defensive guard rationale

The pattern recognizer in `scan-send.sh` survives the cleanup because:
1. The bug last reproduced just yesterday (PR #4 manifestation, 2026-04-27).
2. If it returns under different conditions, a generic "no Body line" FAIL would leave the next debugger guessing.
3. Cost is one `grep -qiE` plus a few echo lines.

The bug arc (`xous-signal-client-notes/bug-arcs/b005`) preserves the full investigation history. If a regression occurs, re-open issue #8 with reproduction steps.

## Test plan

- [x] Three consecutive `./tools/scan-send.sh` runs → all PASS leg-1 + leg-2 (output above).
- [x] `cargo test --features hosted` → 111 passed, 0 failed, 13 ignored (unchanged).
- [x] `bash -n` clean on both modified scripts.
- [x] No `KNOWN_FAIL` orphan refs left in the codebase (grep clean).

## Acceptance-criteria mapping (issue #8)

- [x] Reproduce reliably → **inverted**: confirmed *not* reproducible across 3 runs after the receive-sibling fix.
- [x] Either ship a fix or document as permanent limitation → effectively shipped via the receive-sibling fix in #30. The send-direction symptom appears to share the same root cause (cross-end session-state divergence). The defensive recognizer documents the contract.
- [x] Update `tests/known-issues.md`, `tests/README.md`, `tools/scan-send.sh` exit-87 path → done.

Closes #8.