### PR TITLE
docs(agents): clarify sigchat is the canonical xous-core app name

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -81,8 +81,12 @@ an infinite `register_ux: lend_mut` loop (IPC format mismatch).
 ```bash
 cd ~/workdir/xous-core
 cargo xtask run sigchat:../xous-signal-client/target/release/xous-signal-client
-# Note: uses `sigchat:` xtask alias — xous-signal-client is registered
-# in xous-core's app-allowlist under that name (see "What this is").
+# Note: `sigchat` is the in-tree app name in xous-core's apps/manifest.json.
+# This is the canonical xtask invocation — not an alias around a missing
+# entry. The project-level repo is named xous-signal-client (the binary
+# path on the right of `:`); xous-core knows this app as `sigchat` (the
+# manifest key on the left). See "What this is" above for why these names
+# differ and why renaming the manifest entry would be invasive.
 ```
 
 The emulator window appears on whichever X display is active when


### PR DESCRIPTION
## Summary

Issue #14 was filed on inaccurate premise. The manifest entry **already exists** at `apps/manifest.json:97`:

```json
"sigchat": {
    "context_name": "signal",
    "menu_name": { "appmenu.sigchat": { ... } },
    "submenu": 1
},
```

What looks like a "workaround alias" in `cargo xtask run sigchat:...` is actually the canonical form: `sigchat` is the manifest key, `xous-signal-client` is the binary name. The two appear together because the binary path is supplied as the run target.

## What this PR does

Re-words the AGENTS.md "Run hosted" comment to remove the misleading "uses `sigchat:` xtask alias" phrasing. Replaces with: "this is the canonical xtask invocation — not an alias around a missing entry."

The "What this is" section (lines 14-25) already explains why the names differ and includes the "Do not rename these in this repo" hard rule. This PR just makes the "Run hosted" comment consistent with that earlier section.

## Why not add a duplicate `xous-signal-client` entry?

The original issue asked for a duplicate entry so newcomers wouldn't have to mentally translate `sigchat → xous-signal-client`. Two reasons not to:

1. **Menu duplication.** xous-core's app menu would show both "sigchat" and "xous-signal-client" pointing at the same code — UX-bad.
2. **Renaming has downstream effects.** AGENTS.md "What this is" explicitly says `gam::APP_NAME_SIGCHAT`, `SigchatOp::*`, and `sigchat.*` PDDB dict prefixes all depend on the in-tree name. Adding a duplicate manifest entry doesn't rename them, but it implies a future rename that would touch all those.

The existing single-entry + AGENTS.md explanation is the cleanest state.

## Test plan

- [x] No code change. Doc-only.
- [x] AGENTS.md still passes basic markdown structure (header levels, code-block fencing).
- [ ] Reviewer agrees the new wording is clearer than "alias".

Closes #14.