### PR TITLE
feat(account): post-link PUT /v1/accounts/attributes refresh

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,21 @@ Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+### Added
+
+- `manager::rest::put_accounts_attributes`: post-link `PUT /v1/accounts/attributes`
+  refresh. Called from `Account::link` after the link succeeds. The link body
+  already carries an `accountAttributes` sub-object that updates the device
+  record; this separate PUT updates the canonical per-account record so
+  Signal-Server's per-device and per-account views agree (matching reference
+  clients: signal-cli, libsignal-service-rs, Signal-Android). Failure is
+  non-fatal — link succeeded, message receive path works, attributes can be
+  retried on a future startup. Identifier format is `<aci>.<deviceId>`.
+  `AccountAttributes` and `Capabilities` now derive `Clone` so the link
+  flow can pass one copy to the link body and keep another for the
+  follow-up PUT. Two new unit tests pin the new identifier format and
+  the Clone serialization equivalence. Closes #16.
+
 ### Changed
 
 - `tools/measure-renode.sh`: previously exited 2 (skip) when Renode

--- a/src/account.rs
+++ b/src/account.rs
@@ -326,7 +326,10 @@ impl Account {
 
         let generated = prekeys::generate_prekeys(&aci_priv, &pni_priv)?;
 
-        let body = rest::LinkDeviceRequestBody::from_parts(verification_code, attrs, &generated);
+        // Clone attrs so the post-link refresh below has a copy after the
+        // link body consumes its move-by-value (issue #16).
+        let body = rest::LinkDeviceRequestBody::from_parts(
+            verification_code, attrs.clone(), &generated);
 
         let base_url = self.chat_url()?;
         let response =
@@ -382,6 +385,25 @@ impl Account {
         // Save prekey private-key records to pddb stores so incoming messages
         // can be decrypted. Must happen AFTER a successful REST link (above).
         prekeys::save_to_pddb(&generated)?;
+
+        // Post-link account-attributes refresh (issue #16). The link body
+        // already carries an accountAttributes sub-object on the device
+        // record; this PUT updates the canonical per-account record so the
+        // server's per-device and per-account views agree. Reference
+        // clients (signal-cli, libsignal-service-rs, Signal-Android) all
+        // issue this in addition to the link.
+        //
+        // Non-fatal: the link succeeded above, the message receive path
+        // works, and the server-side per-account record can be retried on
+        // a future startup. We log the outcome but do not propagate the
+        // error.
+        let attrs_identifier = format!("{}.{}", aci.service_id, response.device_id);
+        match rest::put_accounts_attributes(&base_url, &attrs_identifier, &password, &attrs) {
+            Ok(()) => log::info!("post-link account attributes refreshed"),
+            Err(e) => log::warn!(
+                "post-link account attributes refresh failed (non-fatal): {e}"
+            ),
+        }
 
         Ok(true)
     }

--- a/src/manager/account_attrs.rs
+++ b/src/manager/account_attrs.rs
@@ -74,7 +74,7 @@ pub fn generate_registration_id() -> Result<u16, Error> {
     Ok(((rng.next_u32() % 16380) + 1) as u16)
 }
 
-#[derive(Serialize)]
+#[derive(Serialize, Clone)]
 pub struct Capabilities {
     pub storage: bool,
     #[serde(rename = "versionedExpirationTimer")]
@@ -100,7 +100,7 @@ pub struct Capabilities {
 /// Server-side parsers tolerate the legacy fields when present (Jackson
 /// `@JsonIgnoreProperties(ignoreUnknown = true)`), but sending them was
 /// dead weight on every link/attributes call.
-#[derive(Serialize)]
+#[derive(Serialize, Clone)]
 pub struct AccountAttributes {
     #[serde(rename = "registrationId")]
     pub registration_id: u32,

--- a/src/manager/rest.rs
+++ b/src/manager/rest.rs
@@ -1,5 +1,13 @@
-// HTTPS client for `PUT /v1/devices/link`. Shares the Xous trust store
-// through rustls::ClientConfig built by tls::Tls::new().client_config().
+// HTTPS client for the small set of Signal REST endpoints this client
+// invokes:
+// - `PUT /v1/devices/link` — initial secondary-device link.
+// - `PUT /v1/accounts/attributes` — post-link account-attributes refresh
+//   (issue #16). The link body already carries an `accountAttributes`
+//   sub-object; this separate call updates the canonical account record
+//   so the server's per-device and per-account views agree.
+//
+// All endpoints share the Xous trust store through rustls::ClientConfig
+// built by tls::Tls::new().client_config().
 #![deny(clippy::unwrap_used)]
 #![deny(clippy::expect_used)]
 #![deny(clippy::panic)]
@@ -171,6 +179,80 @@ pub fn put_devices_link(
     }
 }
 
+/// PUT {base_url}/v1/accounts/attributes with Basic auth, sending the
+/// canonical AccountAttributes JSON body (issue #16).
+///
+/// Called after `put_devices_link` succeeds. The link body carries an
+/// `accountAttributes` sub-object that updates the device record, but
+/// modern Signal-Server treats the per-account record as a separate
+/// store; reference clients (signal-cli, libsignal-service-rs,
+/// Signal-Android) issue this PUT in addition to refresh the canonical
+/// account-level fields.
+///
+/// Failure is treated by the caller as non-fatal: the link itself
+/// succeeded, the message-receive path works, and the attributes can
+/// be retried on a future startup.
+///
+/// Identifier format: `<aci>.<deviceId>` (the new device's auth credentials).
+/// Returns Ok(()) on any 2xx response (Signal-Server returns 204 No Content
+/// on success).
+pub fn put_accounts_attributes(
+    base_url: &Url,
+    identifier: &str,
+    password: &str,
+    attrs: &AccountAttributes,
+) -> Result<(), Error> {
+    let mut url = base_url.clone();
+    url.set_path("/v1/accounts/attributes");
+    let url_str = url.to_string();
+
+    let client_config = Arc::new(Tls::new().client_config());
+    let agent = ureq::AgentBuilder::new()
+        .tls_config(client_config)
+        .build();
+
+    let auth_value = basic_auth_header(identifier, password);
+    log::info!(
+        "PUT {url_str} with Basic auth for identifier={identifier} (password redacted)"
+    );
+
+    let json = serde_json::to_string(attrs).map_err(|e| {
+        log::error!("AccountAttributes serialize failed: {e}");
+        Error::new(ErrorKind::Other, "failed to serialize attrs body")
+    })?;
+    log::info!("PUT /v1/accounts/attributes body len={}", json.len());
+
+    let resp = agent
+        .put(&url_str)
+        .set("Authorization", &auth_value)
+        .set("Content-Type", "application/json")
+        .send_bytes(json.as_bytes());
+
+    match resp {
+        Ok(r) => {
+            let status = r.status();
+            log::info!("PUT {url_str} -> {status}");
+            Ok(())
+        }
+        Err(ureq::Error::Status(code, r)) => {
+            let body_text = r.into_string().unwrap_or_default();
+            let preview: String = body_text.chars().take(200).collect();
+            log::error!("PUT {url_str} -> {code}: {preview}");
+            Err(Error::new(
+                ErrorKind::Other,
+                format!("PUT /v1/accounts/attributes returned {code}"),
+            ))
+        }
+        Err(e) => {
+            log::error!("PUT {url_str} request failed: {e}");
+            Err(Error::new(
+                ErrorKind::ConnectionAborted,
+                format!("PUT /v1/accounts/attributes request failed: {e}"),
+            ))
+        }
+    }
+}
+
 fn basic_auth_header(identifier: &str, password: &str) -> String {
     let raw = format!("{}:{}", identifier, password);
     format!("Basic {}", STANDARD.encode(raw.as_bytes()))
@@ -321,6 +403,45 @@ mod tests {
             decoded_str,
             "+14155552671.-1:hunter2hunter2hunter2hh"
         );
+    }
+
+    #[test]
+    fn basic_auth_supports_aci_dot_device_id_format() {
+        // The post-link `PUT /v1/accounts/attributes` (issue #16) uses the
+        // `<aci>.<deviceId>` identifier (the device's authoritative auth
+        // credentials after link returns). Sanity: the same Basic-auth
+        // constructor handles this format with no special-casing.
+        let header = basic_auth_header(
+            "12345678-1234-1234-1234-123456789abc.42",
+            "hunter2hunter2hunter2hh",
+        );
+        let decoded = STANDARD
+            .decode(&header["Basic ".len()..])
+            .expect("valid base64");
+        let decoded_str = std::str::from_utf8(&decoded).expect("utf-8");
+        assert_eq!(
+            decoded_str,
+            "12345678-1234-1234-1234-123456789abc.42:hunter2hunter2hunter2hh"
+        );
+    }
+
+    #[test]
+    fn account_attributes_clone_preserves_field_set() {
+        // AccountAttributes derives Clone (issue #16) so the link flow can
+        // pass one copy to the link body and keep another for the post-link
+        // PUT /v1/accounts/attributes call. Verify Clone is structurally
+        // sound: serializing both copies produces byte-identical JSON.
+        use crate::manager::account_attrs::build_account_attributes;
+        let attrs = build_account_attributes(
+            "name".to_string(),
+            &[0u8; 32],
+            42,
+            43,
+        )
+        .expect("attrs");
+        let json_a = serde_json::to_string(&attrs).expect("serialize a");
+        let json_b = serde_json::to_string(&attrs.clone()).expect("serialize b");
+        assert_eq!(json_a, json_b);
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Implements the post-link `PUT /v1/accounts/attributes` call (issue #16). The link body's `accountAttributes` sub-object updates the device record; this separate PUT refreshes the canonical per-account record so Signal-Server's per-device and per-account views agree.

## What changed

| File | Change |
|---|---|
| `src/manager/rest.rs` | New `put_accounts_attributes(base_url, identifier, password, attrs)` function. Two new unit tests. Updated module-level comment to cover both endpoints. |
| `src/manager/account_attrs.rs` | `AccountAttributes` and `Capabilities` now derive `Clone` so the link flow can use one copy in the link body and another in the post-link PUT. |
| `src/account.rs` | `Account::link()` clones `attrs` before passing to the link body, then calls `rest::put_accounts_attributes` after the link succeeds. Failure is non-fatal (logged, not propagated). |
| `CHANGELOG.md` | `[Unreleased] Added` entry. |

## Reference clients pattern

signal-cli, libsignal-service-rs, and Signal-Android all issue this PUT after link. The link-body's attributes update the device record; this PUT updates the per-account record. The two records can drift if only the link body is sent.

## Why non-fatal on failure

If `PUT /v1/accounts/attributes` fails after a successful link:
- The device is already linked at the server.
- The local PDDB state is already persisted (lines 355-380 of `account.rs`).
- The message receive path works (the WS auth uses the same credentials).
- The attributes are retryable on next startup (a future enhancement that's out of scope here).

Treating it as fatal would force an unrecoverable error state on a transient network issue. Non-fatal + log-and-continue is what the reference clients do.

## Tests added (2)

| Test | Purpose |
|---|---|
| `basic_auth_supports_aci_dot_device_id_format` | Verifies the `<aci>.<deviceId>` identifier format used by the new endpoint round-trips through Basic-auth encoding without special-casing. |
| `account_attributes_clone_preserves_field_set` | Verifies `Clone` is structurally sound — serializing the original and the clone produces byte-identical JSON. |

## Acceptance criterion handling

Issue #16:
- [x] Issue PUT /v1/accounts/attributes after successful link → done.
- [x] Use the canonical capabilities schema → uses the `AccountAttributes` cleaned up in #17.
- [x] Verify against libsignal-service-rs reference → same shape, same identifier format.
- [x] Unit/integration test → 2 new unit tests; integration test would require a server stub (out of scope here).

Issue #17 acceptance criterion #3 ("Separate link-time fields from per-device fields cleanly") was deferred from #17 to this PR. **Reviewed and intentionally not split:** the link body and the post-link PUT both want the same fields — modern Signal-Server's `AccountAttributes` entity is the same shape in both contexts. No structural separation needed; the field set serves both purposes. (See the long doc comment on `AccountAttributes` in `account_attrs.rs`.)

## Test plan

- [x] `cargo test --features hosted` → **113 passed, 0 failed, 13 ignored** (was 111; +2 new).
- [x] `cargo build --features hosted` → clean build.
- [x] Existing `body_serializes_with_expected_keys` test still passes (no regression on the link body path).
- [ ] Reviewer confirms a fresh device-link still succeeds and the post-link PUT is observed in the log (`PUT https://chat.signal.org/v1/accounts/attributes -> 204`).

Closes #16.