### PR TITLE
perf(stores): consolidate to one Pddb handle per envelope dispatch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Changed
 
+- `main_ws::dispatch_envelope` now uses a single shared `Rc<pddb::Pddb>`
+  across all five protocol stores instead of allocating a fresh
+  `pddb::Pddb::new()` per store. Each `Pddb::new()` invokes
+  `xns.request_connection_blocking` (an RPC); the consolidation drops
+  per-envelope PDDB connection-request RPCs from 5 to 1, and `try_mount`
+  calls from 5 to 1. New `*Store::new_shared(pddb: Rc<pddb::Pddb>, ...)`
+  constructors expose the consolidation pattern; the existing
+  `*Store::new(pddb: Pddb, ...)` constructors stay backward-compatible
+  (they wrap in `Rc` internally). Closes #26.
 - `tools/measure-renode.sh`: previously exited 2 (skip) when Renode
   refused to compile `LiteX_Timer_32.cs` due to a `long`/`ulong`
   mismatch against Renode 1.16.1. The cast itself is now fixed in

--- a/src/manager/main_ws.rs
+++ b/src/manager/main_ws.rs
@@ -10,6 +10,7 @@
 #![deny(clippy::panic)]
 
 use std::convert::TryFrom as _;
+use std::rc::Rc;
 use futures::executor::block_on;
 use base64::{engine::general_purpose::STANDARD as BASE64, Engine as _};
 use libsignal_protocol::{
@@ -426,17 +427,18 @@ fn dispatch_envelope(body: Vec<u8>, local_addr: &ProtocolAddress, chat_cid: CID)
         }
     };
 
-    let pddb_id = pddb::Pddb::new(); pddb_id.try_mount();
-    let pddb_pk = pddb::Pddb::new(); pddb_pk.try_mount();
-    let pddb_spk = pddb::Pddb::new(); pddb_spk.try_mount();
-    let pddb_kpk = pddb::Pddb::new(); pddb_kpk.try_mount();
-    let pddb_ses = pddb::Pddb::new(); pddb_ses.try_mount();
+    // Single shared PDDB handle across all five stores (issue #26). Each
+    // `pddb::Pddb::new()` makes a fresh `xns.request_connection_blocking`
+    // RPC; cloning the `Rc` is a refcount bump. Per-envelope wins: 5 → 1
+    // PDDB connection-request RPCs, 5 → 1 try_mount calls.
+    let pddb = Rc::new(pddb::Pddb::new());
+    pddb.try_mount();
 
-    let mut identity_store = PddbIdentityStore::new(pddb_id, ACCOUNT_DICT, IDENTITY_DICT);
-    let mut pre_key_store = PddbPreKeyStore::new(pddb_pk, PREKEY_DICT);
-    let signed_pre_key_store = PddbSignedPreKeyStore::new(pddb_spk, SIGNED_PREKEY_DICT);
-    let mut kyber_pre_key_store = PddbKyberPreKeyStore::new(pddb_kpk, KYBER_PREKEY_DICT);
-    let mut session_store = PddbSessionStore::new(pddb_ses, SESSION_DICT);
+    let mut identity_store = PddbIdentityStore::new_shared(pddb.clone(), ACCOUNT_DICT, IDENTITY_DICT);
+    let mut pre_key_store = PddbPreKeyStore::new_shared(pddb.clone(), PREKEY_DICT);
+    let signed_pre_key_store = PddbSignedPreKeyStore::new_shared(pddb.clone(), SIGNED_PREKEY_DICT);
+    let mut kyber_pre_key_store = PddbKyberPreKeyStore::new_shared(pddb.clone(), KYBER_PREKEY_DICT);
+    let mut session_store = PddbSessionStore::new_shared(pddb, SESSION_DICT);
     let mut rng = rand::rngs::OsRng.unwrap_err();
 
     // Sealed sender: sender identity is encrypted inside the ciphertext.

--- a/src/manager/stores.rs
+++ b/src/manager/stores.rs
@@ -6,6 +6,7 @@
 
 use async_trait::async_trait;
 use std::io::{Read, Write};
+use std::rc::Rc;
 use base64::{engine::general_purpose::URL_SAFE_NO_PAD, Engine as _};
 use libsignal_protocol::{
     Direction, IdentityChange, IdentityKey, IdentityKeyPair, IdentityKeyStore,
@@ -24,13 +25,25 @@ type SignalResult<T> = std::result::Result<T, SignalProtocolError>;
 // ---------------------------------------------------------------------------
 
 pub struct PddbIdentityStore {
-    pddb: pddb::Pddb,
+    pddb: Rc<pddb::Pddb>,
     account_dict: &'static str,
     identity_dict: &'static str,
 }
 
 impl PddbIdentityStore {
+    /// Construct from an owned `Pddb` handle. Internally wraps in `Rc` so
+    /// the store can coexist with other stores sharing the same handle —
+    /// see [`new_shared`] for the consolidated-dispatch entry point
+    /// (issue #26).
     pub fn new(pddb: pddb::Pddb, account_dict: &'static str, identity_dict: &'static str) -> Self {
+        Self::new_shared(Rc::new(pddb), account_dict, identity_dict)
+    }
+
+    /// Construct from a shared (`Rc`-wrapped) `Pddb` handle. Cheaper than
+    /// [`new`] when multiple stores share a single underlying connection.
+    /// Used by `main_ws::dispatch_envelope` to drop from 5 `Pddb::new()`
+    /// RPCs per inbound envelope to 1 (issue #26).
+    pub fn new_shared(pddb: Rc<pddb::Pddb>, account_dict: &'static str, identity_dict: &'static str) -> Self {
         Self { pddb, account_dict, identity_dict }
     }
 }
@@ -142,12 +155,17 @@ impl IdentityKeyStore for PddbIdentityStore {
 // ---------------------------------------------------------------------------
 
 pub struct PddbPreKeyStore {
-    pddb: pddb::Pddb,
+    pddb: Rc<pddb::Pddb>,
     dict: &'static str,
 }
 
 impl PddbPreKeyStore {
     pub fn new(pddb: pddb::Pddb, dict: &'static str) -> Self {
+        Self::new_shared(Rc::new(pddb), dict)
+    }
+
+    /// See [`PddbIdentityStore::new_shared`] (issue #26).
+    pub fn new_shared(pddb: Rc<pddb::Pddb>, dict: &'static str) -> Self {
         Self { pddb, dict }
     }
 }
@@ -208,12 +226,17 @@ impl PreKeyStore for PddbPreKeyStore {
 // ---------------------------------------------------------------------------
 
 pub struct PddbSignedPreKeyStore {
-    pddb: pddb::Pddb,
+    pddb: Rc<pddb::Pddb>,
     dict: &'static str,
 }
 
 impl PddbSignedPreKeyStore {
     pub fn new(pddb: pddb::Pddb, dict: &'static str) -> Self {
+        Self::new_shared(Rc::new(pddb), dict)
+    }
+
+    /// See [`PddbIdentityStore::new_shared`] (issue #26).
+    pub fn new_shared(pddb: Rc<pddb::Pddb>, dict: &'static str) -> Self {
         Self { pddb, dict }
     }
 }
@@ -252,12 +275,17 @@ impl SignedPreKeyStore for PddbSignedPreKeyStore {
 // ---------------------------------------------------------------------------
 
 pub struct PddbKyberPreKeyStore {
-    pddb: pddb::Pddb,
+    pddb: Rc<pddb::Pddb>,
     dict: &'static str,
 }
 
 impl PddbKyberPreKeyStore {
     pub fn new(pddb: pddb::Pddb, dict: &'static str) -> Self {
+        Self::new_shared(Rc::new(pddb), dict)
+    }
+
+    /// See [`PddbIdentityStore::new_shared`] (issue #26).
+    pub fn new_shared(pddb: Rc<pddb::Pddb>, dict: &'static str) -> Self {
         Self { pddb, dict }
     }
 }
@@ -336,12 +364,17 @@ impl KyberPreKeyStore for PddbKyberPreKeyStore {
 // ---------------------------------------------------------------------------
 
 pub struct PddbSessionStore {
-    pddb: pddb::Pddb,
+    pddb: Rc<pddb::Pddb>,
     dict: &'static str,
 }
 
 impl PddbSessionStore {
     pub fn new(pddb: pddb::Pddb, dict: &'static str) -> Self {
+        Self::new_shared(Rc::new(pddb), dict)
+    }
+
+    /// See [`PddbIdentityStore::new_shared`] (issue #26).
+    pub fn new_shared(pddb: Rc<pddb::Pddb>, dict: &'static str) -> Self {
         Self { pddb, dict }
     }
 


### PR DESCRIPTION
## Summary

Drops per-envelope PDDB connection-request RPCs from **5 → 1** by sharing one `Rc<pddb::Pddb>` across all five protocol stores in `main_ws::dispatch_envelope`. Closes issue #26.

## Why

Each `pddb::Pddb::new()` invokes `xns.request_connection_blocking(SERVER_NAME_PDDB)` — a real RPC roundtrip. Five new()s + five try_mount()s per inbound envelope was the documented overhead in #26 ("Five PDDB handles per envelope dispatch (perf polish)").

After this PR, dispatch_envelope:
- Allocates one `Rc<pddb::Pddb>`
- Calls `.try_mount()` once
- Clones the `Rc` into each store (refcount bump, no RPC)

## What changed

| File | Change |
|---|---|
| `src/manager/stores.rs` | All five store struct fields changed from `pddb: pddb::Pddb` to `pddb: Rc<pddb::Pddb>`. Each `*Store::new` now wraps the input in `Rc::new()` internally — backward-compatible. New `*Store::new_shared(pddb: Rc<pddb::Pddb>, ...)` constructors expose the consolidation case. Imports `std::rc::Rc`. |
| `src/manager/main_ws.rs` | `dispatch_envelope` builds one `Rc<pddb::Pddb>` and clones it into each `*Store::new_shared` call. Imports `std::rc::Rc`. |
| `CHANGELOG.md` | `[Unreleased] Changed` entry. |

## Backward compatibility

- `*Store::new(pddb: pddb::Pddb, ...)` signatures **unchanged**. Tests, `prekeys.rs`, `account.rs`, and `src/bin/test_stores.rs` continue to use them with no edits.
- Internal method calls use `&self.pddb`, which auto-derefs through `Rc<T>::Deref → &T`. No method body changes needed.

## Test plan

- [x] `cargo build --features hosted` → clean.
- [x] `cargo test --features hosted` → **111 passed, 0 failed, 13 ignored** (unchanged).
- [x] Existing `PddbStore` tests exercise `*Store::new` — they now go through `Rc::new()` → `new_shared`. Same observable behavior.
- [ ] Reviewer confirms the `Rc` consolidation matches `Pddb`'s thread-safety model (single-threaded; `Pddb` contains `RefCell` so `Rc` is correct, not `Arc`).

## Acceptance-criteria mapping (issue #26)

- [x] Profile current dispatch path; confirm 5 handles → confirmed at `main_ws.rs:429-433` pre-refactor.
- [x] Consolidate where possible (cache long-lived handles, batch reads) → 5 → 1 in dispatch_envelope. Other consumers each use a single store; no further consolidation benefit.
- [ ] Benchmark before/after under the backlog-drain scenario → requires running emulator with timing instrumentation; deferred. The saved RPCs are deterministic (4 fewer connection-requests + 4 fewer try_mount calls per envelope), so absent perf testing the win is structural rather than measured.

Closes #26.