### PR TITLE
chore: rename xous-core dev branch to dev-for-xous-signal-client

### DIFF
--- a/.github/workflows/size-budget.yml
+++ b/.github/workflows/size-budget.yml
@@ -21,7 +21,7 @@ jobs:
       TARGET: riscv32imac-unknown-xous-elf
       BIN_NAME: xous-signal-client
       FEATURES: precursor
-      XOUS_CORE_BRANCH: feat/05-curve25519-dalek-4.1.3
+      XOUS_CORE_BRANCH: dev-for-xous-signal-client
     steps:
       - uses: actions/checkout@v4
 
@@ -78,7 +78,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 20
     env:
-      XOUS_CORE_BRANCH: feat/05-curve25519-dalek-4.1.3
+      XOUS_CORE_BRANCH: dev-for-xous-signal-client
     steps:
       - uses: actions/checkout@v4
 

--- a/.github/workflows/size-delta.yml
+++ b/.github/workflows/size-delta.yml
@@ -19,7 +19,7 @@ jobs:
       TARGET: riscv32imac-unknown-xous-elf
       BIN_NAME: xous-signal-client
       FEATURES: precursor
-      XOUS_CORE_BRANCH: feat/05-curve25519-dalek-4.1.3
+      XOUS_CORE_BRANCH: dev-for-xous-signal-client
     steps:
       - uses: actions/checkout@v4
         with:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -35,7 +35,7 @@ now distinct. Practical implications:
   toolchain (downloads a betrusted-io fork of the Rust compiler with
   pre-built std).
 
-- **`xous-core` checked out on branch `feat/05-curve25519-dalek-4.1.3`.**
+- **`xous-core` checked out on branch `dev-for-xous-signal-client`.**
   This is non-negotiable — other branches pin `root-keys` to
   `curve25519-dalek = "=4.1.2"` which conflicts with this project's
   requirement of 4.1.3. The branch carries several local patches; see
@@ -176,7 +176,7 @@ In particular:
 
 - `betrusted-io/xous-core` is an upstream dependency. Local patches
   needed by this project are carried on the locally-pinned branch
-  (currently `feat/05-curve25519-dalek-4.1.3`) and tracked via PRs
+  (currently `dev-for-xous-signal-client`) and tracked via PRs
   against `tunnell/xous-core` (the project's fork). They are NOT
   pushed to or PR'd against `betrusted-io/xous-core`.
 - The same rule applies to any other dependency repo (signal-cli,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -63,6 +63,18 @@ Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Changed
 
+- Renamed the pinned `tunnell/xous-core` branch from
+  `feat/05-curve25519-dalek-4.1.3` to `dev-for-xous-signal-client`.
+  The old name encoded its leading patch (curve25519-dalek 4.1.2 →
+  4.1.3 bump); the branch now carries multiple unrelated patches
+  (Renode `LiteX_Timer_32` cast, TLS refactor + revert, chat-lib
+  `set_author_flags`) and the purpose-named ref is more
+  discoverable. Updated AGENTS.md, TESTING-PLAN.md, tests/README.md,
+  the four `tools/*.sh` scan scripts, and the `XOUS_CORE_BRANCH`
+  env in both size-CI workflows. ADR 0012 retains the old name as
+  historical record (MADR convention: ADRs are immutable). The
+  GitHub branch rename was atomic; no PRs were affected (none were
+  open against the old ref).
 - ADR 0011 (`docs/decisions/0011-affirm-hand-rolled-with-stop-loss-criteria.md`)
   reaffirms the hand-rolled libsignal-protocol orchestration choice and
   replaces ADR 0001's "open architectural alternative" caveat with concrete
@@ -143,7 +155,7 @@ Changelog](https://keepachangelog.com/en/1.1.0/).
   `chat.set_author_flags("me", AuthorFlag::Right)` after `dialogue_set`
   so outgoing local-echo bubbles render on the conventional sender
   side. Depends on the `Chat::set_author_flags` API added to chat-lib
-  on the project's pinned `feat/05-curve25519-dalek-4.1.3` branch
+  on the project's pinned `dev-for-xous-signal-client` branch
   (tracked in `xous-signal-client-notes/techContext.md` patch table).
 - `tools/demo-prep.sh`: recording-day setup script. Restores the PDDB
   snapshot, looks up the emulator's UUID via signal-cli's `recipient`

--- a/TESTING-PLAN.md
+++ b/TESTING-PLAN.md
@@ -22,7 +22,7 @@ git branch --show-current   # confirm intended branch
 git status                  # working tree state matches expectations
 
 cd ~/workdir/xous-core
-git branch --show-current   # must be feat/05-curve25519-dalek-4.1.3
+git branch --show-current   # must be dev-for-xous-signal-client
 ```
 
 If anything looks wrong, stop and report before doing anything else.
@@ -35,14 +35,14 @@ the wrong branch:
 
 ```bash
 cd ~/workdir/xous-core
-git checkout feat/05-curve25519-dalek-4.1.3
+git checkout dev-for-xous-signal-client
 ```
 
 ## Required checks before reporting "done"
 
 ### Check 1: Build succeeds for Xous target
 
-**Prerequisite:** xous-core on `feat/05-curve25519-dalek-4.1.3` (see Pre-flight).
+**Prerequisite:** xous-core on `dev-for-xous-signal-client` (see Pre-flight).
 
 ```bash
 cd ~/workdir/xous-signal-client

--- a/tests/README.md
+++ b/tests/README.md
@@ -59,7 +59,7 @@ section). The infrastructure is preserved for future use.
 
 1. Install the Rust toolchain xous-core uses (see `xous-core`'s
    own README for the pinned toolchain). The project pins to
-   `feat/05-curve25519-dalek-4.1.3` of `tunnell/xous-core` for path
+   `dev-for-xous-signal-client` of `tunnell/xous-core` for path
    dependencies — see `TESTING-PLAN.md` Pre-flight.
 2. (Optional, for E2E) Install `signal-cli`, set up two test Signal
    accounts, link them, and populate `tools/.env`. See

--- a/tools/measure-renode.sh
+++ b/tools/measure-renode.sh
@@ -14,7 +14,7 @@
 # Prerequisites:
 #   - Renode v1.16.1 or later on PATH
 #   - xous-core checkout at $XOUS_CORE_PATH (default ../xous-core) on
-#     branch feat/05-curve25519-dalek-4.1.3
+#     branch dev-for-xous-signal-client
 #   - xous-signal-client release binary already built for the Xous
 #     target (run measure-size.sh first if needed)
 #

--- a/tools/measure-size.sh
+++ b/tools/measure-size.sh
@@ -10,7 +10,7 @@
 #   - riscv64-unknown-elf binutils (size, readelf) on PATH
 #   - cargo-bloat installed (cargo install cargo-bloat)
 #   - xous-core checkout at ../xous-core (or $XOUS_CORE_PATH) on
-#     branch feat/05-curve25519-dalek-4.1.3
+#     branch dev-for-xous-signal-client
 #   - Python 3.11+ (or pip install tomli for older)
 #
 # Output:

--- a/tools/scan-receive.sh
+++ b/tools/scan-receive.sh
@@ -35,7 +35,7 @@
 #   - X11 display (default :10) where the emulator window appears
 #   - python3 (ctypes; usually present)
 #   - xous-core checkout at $XOUS_CORE_PATH on
-#     feat/05-curve25519-dalek-4.1.3
+#     dev-for-xous-signal-client
 #
 # Output:
 #   - Emulator scan log to /tmp/xsc-recv-<timestamp>.log

--- a/tools/scan-send.sh
+++ b/tools/scan-send.sh
@@ -20,7 +20,7 @@
 #   - X11 display (default :10) where the emulator window appears
 #   - python3 with X11 bindings (ctypes; usually present)
 #   - xous-core checkout at $XOUS_CORE_PATH (default ../xous-core) on
-#     branch feat/05-curve25519-dalek-4.1.3
+#     branch dev-for-xous-signal-client
 #
 # Output:
 #   - Wire bytes to /tmp/xsc-wire-dump.txt (XSCDEBUG_DUMP=1)


### PR DESCRIPTION
Renames the locally-pinned tracking branch on tunnell/xous-core
from feat/05-curve25519-dalek-4.1.3 (named after its leading
patch — a curve25519-dalek 4.1.2 → 4.1.3 bump) to
dev-for-xous-signal-client (named after its purpose). The
branch now carries multiple unrelated patches (LiteX_Timer_32
cast for Renode 1.16+, TLS refactor + revert, chat-lib
set_author_flags) and the version-named ref no longer reflects
its scope.

Updates this repo's references to point at the renamed branch:
AGENTS.md, TESTING-PLAN.md, tests/README.md, the four
tools/*.sh scan scripts, .github/workflows/size-{budget,delta}.yml,
and the [Unreleased] CHANGELOG entry. ADR 0012 retains the old
name as historical record (MADR convention: ADRs are immutable;
the branch name was correct at time of writing).

Companion change: tunnell/xous-core's branch has been renamed
via the GitHub branch-rename API. No PRs were affected (none
were open against the old ref).

## Test plan

- [ ] Build still green against the renamed branch
- [ ] No stale feat/05-curve25519 references in docs/
- [ ] tools/ scripts find the right xous-core branch on a fresh checkout

Generated with an AI agent.