### PR TITLE
fix(ux): close first-run WiFi trap (#42, Session A)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -61,6 +61,41 @@ Changelog](https://keepachangelog.com/en/1.1.0/).
   follow-up PUT. Two new unit tests pin the new identifier format and
   the Clone serialization equivalence. Closes #16.
 
+### Fixed
+
+- First-run UX trap when WiFi is unprovisioned (issue #42, Session A
+  of the WiFi-trap fix plan). Four small changes that, together,
+  remove the unrecoverable state a first-time user encountered when
+  launching sigchat without a saved AP:
+  - `main.rs` now calls `gam.allow_mainmenu()` at startup. Previously
+    the Home key only escaped sigchat after pddb had unlocked
+    (which sets the global `allow_mainmenu` flag at
+    `services/pddb/src/main.rs:884, 954`); on a freshly-flashed
+    device with no PIN entered, Home did nothing and the user was
+    trapped. Calling here is idempotent against pddb's own call.
+  - The `close` menu item is no longer a `MenuOp::Noop`. New
+    `MenuOp::CloseApp` variant; the handler at `main.rs` calls
+    `gam.relinquish_focus()` so the user lands back in the launcher
+    while the sigchat process stays warm for fast re-focus.
+  - The hardcoded English `"Connect to WiFi?"` prompt at
+    `lib.rs:553` now routes through `t!()` with a new translation
+    key `sigchat.wifi.connect_prompt`.
+  - The misleading `sigchat.wifi.warning` text changed from "WiFi
+    not connected. Entering read-only mode" to "WiFi unavailable.
+    Some features disabled". The old text claimed the app was
+    entering read-only mode, but `Chat::read_only()` (defined at
+    `xous-core/libs/chat/src/lib.rs:174`) was never actually
+    invoked — the app just sat in its normal state with no
+    dialogue. Renaming is the smallest honest fix; implementing
+    real offline-browse via `Chat::read_only()` is tracked
+    separately as future work.
+
+  Sessions B and C of the fix plan are deferred (UI replacement of
+  the failure-state notification with a structured retry/help/exit
+  screen, and finer-grained failure-mode reporting). The plan
+  document is at
+  `~/workdir/xous-signal-client-notes/_open-followups/2026-05-01-wifi-trap-fix-plan.md`.
+
 ### Changed
 
 - Renamed the pinned `tunnell/xous-core` branch from

--- a/locales/i18n.json
+++ b/locales/i18n.json
@@ -161,10 +161,17 @@
         "zh": "WiFi connected *EN*"
     },
     "sigchat.wifi.warning": {
-        "en": "WiFi not connected. Entering read-only mode",
-        "en-tts": "WiFi not connected Entering read-only mode",
-        "fr": "WiFi pas connecté",
-        "ja": "WiFi not connected.  Entering read-only mode *EN*",
-        "zh": "WiFi not connected.  Entering read-only mode *EN*"
+        "en": "WiFi unavailable. Some features disabled",
+        "en-tts": "WiFi unavailable Some features disabled",
+        "fr": "WiFi indisponible. Certaines fonctionnalités désactivées",
+        "ja": "WiFi unavailable. Some features disabled *EN*",
+        "zh": "WiFi unavailable. Some features disabled *EN*"
+    },
+    "sigchat.wifi.connect_prompt": {
+        "en": "Connect to WiFi?",
+        "en-tts": "Connect to WiFi?",
+        "fr": "Se connecter au WiFi?",
+        "ja": "Connect to WiFi? *EN*",
+        "zh": "Connect to WiFi? *EN*"
     }
 }

--- a/src/api.rs
+++ b/src/api.rs
@@ -18,6 +18,7 @@ pub enum SigchatOp {
 #[derive(Debug, num_derive::FromPrimitive, num_derive::ToPrimitive)]
 pub enum MenuOp {
     Noop,
+    CloseApp,
 }
 
 #[allow(dead_code)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -550,7 +550,7 @@ impl<'a> SigChat<'a> {
         self.modals.add_list_item("yes").expect("failed radio yes");
         self.modals.add_list_item("no").expect("failed radio no");
         self.modals
-            .get_radiobutton("Connect to WiFi?")
+            .get_radiobutton(t!("sigchat.wifi.connect_prompt", locales::LANG))
             .expect("failed radiobutton modal");
         match self.modals.get_radio_index() {
             Ok(button) => button == 0,

--- a/src/main.rs
+++ b/src/main.rs
@@ -53,6 +53,13 @@ fn wrapped_main() -> ! {
         .expect("can't register server");
     log::trace!("registered with NS -- {:?}", sid);
 
+    // Defensively grant Home-key escape to the launcher. The flag is also
+    // set by pddb after PIN unlock; calling here removes the dependency on
+    // PDDB-unlock-having-happened-first, so the user is never trapped in a
+    // sigchat modal without a way to return to the launcher. Closes #42.
+    let gam = gam::Gam::new(&xns).expect("can't connect to GAM");
+    gam.allow_mainmenu().ok();
+
     let chat = Chat::new(
         gam::APP_NAME_SIGCHAT,
         gam::APP_MENU_0_SIGCHAT,
@@ -67,7 +74,7 @@ fn wrapped_main() -> ! {
         name: t!("sigchat.menu.close", locales::LANG).to_string(),
         action_conn: Some(cid),
         action_opcode: SigchatOp::Menu as u32,
-        action_payload: MenuPayload::Scalar([MenuOp::Noop as u32, 0, 0, 0]),
+        action_payload: MenuPayload::Scalar([MenuOp::CloseApp as u32, 0, 0, 0]),
         close_on_select: true,
     })
     .expect("failed add menu");
@@ -175,6 +182,12 @@ fn wrapped_main() -> ! {
                 xous::msg_scalar_unpack!(msg, menu_code, _, _, _, {
                     match FromPrimitive::from_usize(menu_code) {
                         Some(MenuOp::Noop) => {}
+                        Some(MenuOp::CloseApp) => {
+                            // User picked "close" from the app menu. Hand
+                            // focus back to the launcher; keep the app
+                            // process alive so re-focus is fast. Closes #42.
+                            gam.relinquish_focus().ok();
+                        }
                         _ => (),
                     }
                 });


### PR DESCRIPTION
## Summary

Closes #42 via four small surgical changes:

1. `gam.allow_mainmenu()` at startup — the Home key (`'∴'`)
   only escapes apps when this flag is set on the GAM context
   manager (`xous-core/services/gam/src/contexts.rs:741-745`).
   Previously the flag was set by pddb after the user entered
   their PIN; on a freshly-flashed device with no PIN entered,
   no chat-style app could be exited via Home. Calling here
   removes the dependency on PDDB unlock. Idempotent against
   pddb's own call.
2. `MenuOp::CloseApp` makes the existing close menu item
   actually return to the launcher via
   `gam.relinquish_focus()`. Pre-fix it dispatched
   `MenuOp::Noop` and the handler did nothing.
3. The hardcoded English `Connect to WiFi?` prompt at
   `lib.rs:553` now routes through `t!()` against a new
   `sigchat.wifi.connect_prompt` localization key.
4. `sigchat.wifi.warning` text replaced — the prior text
   claimed the app was "Entering read-only mode," but
   `Chat::read_only()` (defined at
   `xous-core/libs/chat/src/lib.rs:174`) was never actually
   invoked. The new text is "WiFi unavailable. Some features
   disabled," which is honest about the app's actual state.

Sessions B (UI replacement of the failure-state modal with
retry/help/exit affordances and FAQ document) and C
(per-failure-mode diagnostics) are deferred per the fix plan
at
`~/workdir/xous-signal-client-notes/_open-followups/2026-05-01-wifi-trap-fix-plan.md`.

## Companion change

This depends on `tunnell/xous-core@dev-for-xous-signal-client`
having the matching locales mirror commit (`e39bf2f41`); the
locales build script scans xous-core only, so the canonical
xsc i18n keys must be mirrored there for the build to see
them. The xous-core fork has been updated. Consumers using a
different xous-core branch would need to apply the same
locales mirror manually.

## Verification done

- `cargo test --features hosted`: 135 passed, 0 failed.
- `cargo build --release --target=riscv32imac-unknown-xous-elf
  --features precursor`: clean (14 pre-existing warnings, no
  new warnings).
- JSON validity check on both i18n.json files: 25 keys,
  parses clean.
- Both i18n.json files (canonical xsc + xous-core mirror)
  byte-identical.

## Smoke-test plan (to run on Precursor before merge)

- [ ] Boot Precursor with WiFi unprovisioned (or skip PIN
      entry to test the deeper case where PDDB stays locked).
- [ ] Launch sigchat from the app launcher. "Connect to
      WiFi?" modal appears.
- [ ] Pick "no". Notification "WiFi unavailable. Some
      features disabled" appears with footer
      "[ Press any key ]".
- [ ] Press the Home key. Notification dismisses; chat UI
      redraws to its empty post-failure state.
- [ ] Press Home again. Returns to launcher.
      (Pre-fix: trapped, required hardware power cycle.)
- [ ] Re-launch sigchat → open app menu (← arrow from chat
      view) → pick "close". Returns to launcher.
      (Pre-fix: was a Noop, did nothing.)

Each box is checked off as the smoke test confirms the fix
works on hardware. The PR is not merged until all boxes are
checked.

## Out of scope

- Implementing actual read-only browse mode using
  `Chat::read_only()` (Direction A from the fix plan;
  deferred as a future feature).
- Upstreaming `allow_mainmenu()` into
  `libs/chat::Chat::new()` for parity with mtxchat (tracked
  separately as a follow-up).
- Per-failure-mode WiFi diagnostics (Session C; deferred
  pending Session B's UI design).

Generated with an AI agent.