### PR TITLE
docs: post-validation BUILDING.md fixes + branch-name reconciliation

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -35,12 +35,15 @@ now distinct. Practical implications:
   toolchain (downloads a betrusted-io fork of the Rust compiler with
   pre-built std).
 
-- **`xous-core` checked out on branch `dev-for-xous-signal-client`.**
-  This is non-negotiable — other branches pin `root-keys` to
-  `curve25519-dalek = "=4.1.2"` which conflicts with this project's
-  requirement of 4.1.3. The branch carries several local patches; see
-  `~/workdir/xous-signal-client-notes/techContext.md` for the patch
-  table with upstream-PR tracking.
+- **`xous-core` checked out on branch `dev`.** This is
+  non-negotiable — other branches (notably `main`) pin `root-keys`
+  to `curve25519-dalek = "=4.1.2"` which conflicts with this
+  project's requirement of 4.1.3. The `dev` branch carries the
+  4.1.3 patch and several other local patches; see
+  `~/workdir/xous-signal-client-notes/techContext.md` for the
+  patch table with upstream-PR tracking.
+  `dev-for-xous-signal-client` was the historical home for these
+  patches and remains usable but is now behind `dev`.
 
 - **`signal-cli`** for end-to-end testing. Linked to one of the test
   accounts as a secondary device.
@@ -176,9 +179,9 @@ In particular:
 
 - `betrusted-io/xous-core` is an upstream dependency. Local patches
   needed by this project are carried on the locally-pinned branch
-  (currently `dev-for-xous-signal-client`) and tracked via PRs
-  against `tunnell/xous-core` (the project's fork). They are NOT
-  pushed to or PR'd against `betrusted-io/xous-core`.
+  (currently `dev`) and tracked via PRs against `tunnell/xous-core`
+  (the project's fork). They are NOT pushed to or PR'd against
+  `betrusted-io/xous-core`.
 - The same rule applies to any other dependency repo (signal-cli,
   libsignal, etc.) referenced during work.
 - If a change to an upstream repo seems valuable for the wider

--- a/BUILDING.md
+++ b/BUILDING.md
@@ -140,16 +140,26 @@ sigchat ELF. Re-run only if `apps/manifest.json` changes.
 cd ~/xous-build/xous-signal-client
 
 cargo build --features hosted                            # library
-cargo test --features hosted --lib                       # 153 tests
-cargo test --features hosted --test wifi_flap_recovery   # 6 tests
+cargo test --features hosted --lib                       # 153 pass, 13 ignored
+cargo test --features hosted --test wifi_flap_recovery   # 6 pass
 ```
 
-Expected result: 153 lib + 6 integration = 159 tests pass.
+Expected result: 153 lib + 6 integration = 159 tests pass. The
+13 ignored lib tests require a Xous IPC server / hosted-mode
+runtime (only available when launched via `cargo xtask run`)
+and are skipped under plain `cargo test`; this is expected, not
+a misconfiguration.
 
 ### Running sigchat itself in hosted mode
 
 `cargo run --features hosted` from xous-signal-client does
-**not** work directly. The `[[bin]]` in `Cargo.toml` declares
+**not** work directly. Bare `cargo run --features hosted`
+errors with `could not determine which binary to run … available
+binaries: test_stores, xous-signal-client` because
+`src/bin/test_stores.rs` is auto-discovered as a second
+binary. Adding `--bin xous-signal-client` then errors with
+`target xous-signal-client … requires the features: precursor`
+— the `[[bin]]` in `Cargo.toml` declares
 `required-features = ["precursor"]` to stop `cargo test
 --features hosted --tests` from accidentally building the
 binary (see the comment above the gate for the underlying

--- a/TESTING-PLAN.md
+++ b/TESTING-PLAN.md
@@ -22,27 +22,30 @@ git branch --show-current   # confirm intended branch
 git status                  # working tree state matches expectations
 
 cd ~/workdir/xous-core
-git branch --show-current   # must be dev-for-xous-signal-client
+git branch --show-current   # must be dev
 ```
 
 If anything looks wrong, stop and report before doing anything else.
 
-**xous-core branch is critical.** Other branches pin `root-keys` to
-`curve25519-dalek = "=4.1.2"` while this project's patched fork
-provides 4.1.3 — cargo fails with a dependency resolution error that
-looks like a project bug but is environment misconfiguration. If on
-the wrong branch:
+**xous-core branch is critical.** `dev` carries the
+`curve25519-dalek = "4.1.3"` patch this project's `root-keys`
+path dependency requires; other branches (notably `main`) pin
+`=4.1.2` and cargo fails with a dependency resolution error that
+looks like a project bug but is environment misconfiguration.
+`dev-for-xous-signal-client` was the historical home for this
+patch and remains usable but is now behind `dev`; new work
+should target `dev`. If on the wrong branch:
 
 ```bash
 cd ~/workdir/xous-core
-git checkout dev-for-xous-signal-client
+git checkout dev
 ```
 
 ## Required checks before reporting "done"
 
 ### Check 1: Build succeeds for Xous target
 
-**Prerequisite:** xous-core on `dev-for-xous-signal-client` (see Pre-flight).
+**Prerequisite:** xous-core on `dev` (see Pre-flight).
 
 ```bash
 cd ~/workdir/xous-signal-client

--- a/tests/README.md
+++ b/tests/README.md
@@ -59,8 +59,9 @@ section). The infrastructure is preserved for future use.
 
 1. Install the Rust toolchain xous-core uses (see `xous-core`'s
    own README for the pinned toolchain). The project pins to
-   `dev-for-xous-signal-client` of `tunnell/xous-core` for path
-   dependencies — see `TESTING-PLAN.md` Pre-flight.
+   the `dev` branch of `tunnell/xous-core` for path
+   dependencies — see `BUILDING.md` and `TESTING-PLAN.md`
+   Pre-flight.
 2. (Optional, for E2E) Install `signal-cli`, set up two test Signal
    accounts, link them, and populate `tools/.env`. See
    `tools/test-env.example` for the configuration template.


### PR DESCRIPTION
## Summary

A fresh cold-start clone-and-build pass against today's `dev` (xous-core `15c06801e`) and `main` (xous-signal-client `55a3541`) surfaced three small doc gaps. All fixes are doc-only.

- **BUILDING.md (hosted lib tests):** `cargo test --features hosted --lib` actually reports "153 passed; 13 ignored". The doc only mentioned 153, so a fresh reader could mistake the skip count for a misconfiguration. The 13 ignored tests require a Xous IPC server / hosted-mode runtime (only available via `cargo xtask run`) — flag this explicitly.
- **BUILDING.md (cargo run failure mode):** Bare `cargo run --features hosted` errors with `could not determine which binary to run … available binaries: test_stores, xous-signal-client` because `src/bin/test_stores.rs` is auto-discovered as a second binary. The "requires the features: precursor" error BUILDING.md quoted only appears once you add `--bin xous-signal-client`. Document both paths.
- **Branch name reconciliation (TESTING-PLAN.md, tests/README.md, AGENTS.md):** BUILDING.md is authoritative ("Branch: **`dev`**. (Not `main`, not `dev-for-xous-signal-client`.)") but the other docs still pointed at the old branch. Align them to `dev` and note `dev-for-xous-signal-client` as the historical home that's now behind `dev`. CHANGELOG entries left untouched as historical record.

## Test plan

- [x] Cold-clone `tunnell/xous-core` `dev` and `tunnell/xous-signal-client` `main` into sibling dirs
- [x] Verify rustc 1.95.0 stable matches `rust-toolchain.toml` pin
- [x] `cargo xtask dummy-template` from xous-core generates the three stub files
- [x] `cargo build --features hosted` from xous-signal-client succeeds
- [x] `cargo test --features hosted --lib` reports `153 passed; 0 failed; 13 ignored`
- [x] `cargo test --features hosted --test wifi_flap_recovery` reports `6 passed; 0 failed`
- [x] `cargo run --features hosted` errors on binary disambiguation; `cargo run --features hosted --bin xous-signal-client` errors with "requires the features: precursor"
- [x] `grep -rn dev-for-xous-signal-client *.md` shows only intentional remaining references (BUILDING.md authoritative line, new historical-context lines, untouched CHANGELOG history)

🤖 Generated with [Claude Code](https://claude.com/claude-code)